### PR TITLE
allow passing feature extractors on init

### DIFF
--- a/src/data_gradients/config/data/typing.py
+++ b/src/data_gradients/config/data/typing.py
@@ -1,5 +1,15 @@
-from typing import Union, Tuple, List, Mapping, Dict
+from typing import Union, Tuple, List, Mapping, Dict, Type
+
+from data_gradients.feature_extractors import AbstractFeatureExtractor
 
 SupportedDataType = Union[Tuple, List, Mapping]
-JSONValue = Union[str, int, float, bool, None, Dict[str, Union["JSONValue", List["JSONValue"]]]]
+JSONValue = Union[
+    str, int, float, bool, None, Dict[str, Union["JSONValue", List["JSONValue"]]]
+]
 JSONDict = Dict[str, JSONValue]
+FeatureExtractorsType = Union[
+    List[Union[str, AbstractFeatureExtractor, Type[AbstractFeatureExtractor]]],
+    str,
+    AbstractFeatureExtractor,
+    Type[AbstractFeatureExtractor],
+]

--- a/src/data_gradients/managers/abstract_manager.py
+++ b/src/data_gradients/managers/abstract_manager.py
@@ -7,6 +7,8 @@ from itertools import zip_longest
 from logging import getLogger
 from tqdm import tqdm
 
+from data_gradients.common.factories import FeatureExtractorsFactory
+from data_gradients.config.utils import load_report_feature_extractors
 from data_gradients.feature_extractors import AbstractFeatureExtractor
 from data_gradients.batch_processors.base import BatchProcessor
 from data_gradients.feature_extractors.common import SummaryStats
@@ -253,3 +255,34 @@ class AnalysisManagerAbstract(abc.ABC):
         msg_train = f"Train set: {self._train_iters_done} out of {total_train_samples} samples were analyzed{portion_train}.\n"
         msg_val = f"Validation set: {self._val_iters_done} out of {total_val_samples} samples were analyzed{portion_val}.\n "
         return msg_head + msg_train + msg_val
+
+    @staticmethod
+    def _get_grouped_feature_extractors(default_config_name: str, config_path: str, feature_extractors) -> Dict[str, List[AbstractFeatureExtractor]]:
+        if feature_extractors is None:
+            if config_path is None:
+                config_dir, config_name = None, default_config_name
+            else:
+                config_path = os.path.abspath(config_path)
+                config_dir, config_name = os.path.dirname(config_path), os.path.basename(config_path).split(".")[0]
+            grouped_feature_extractors = load_report_feature_extractors(config_name=config_name, config_dir=config_dir)
+        else:
+            if not isinstance(feature_extractors, list):
+                feature_extractors = [feature_extractors]
+
+            section_name = "Selected features"
+            grouped_feature_extractors = {section_name: []}
+            for feature_extractor in feature_extractors:
+                if isinstance(feature_extractor, AbstractFeatureExtractor):
+                    grouped_feature_extractors[section_name].append(feature_extractor)
+                elif isinstance(feature_extractor, str):
+                    grouped_feature_extractors[section_name].append(FeatureExtractorsFactory().get(feature_extractor))
+                elif issubclass(feature_extractor, AbstractFeatureExtractor):
+                    try:
+                        grouped_feature_extractors[section_name].append(feature_extractor())
+                    except RuntimeError as e:
+                        raise RuntimeError(f"The feature extractor {feature_extractor.__class__} requires additional init argument. "
+                                           f"Initialize the feature extractor and pass it as an instance")
+                else:
+                    raise RuntimeError(f"Unsupported feature extractor type. Supported types are string (name of FeatureExtractor) or AbstractFeatureExtractor")
+
+        return grouped_feature_extractors

--- a/src/data_gradients/managers/detection_manager.py
+++ b/src/data_gradients/managers/detection_manager.py
@@ -1,9 +1,8 @@
-import os
-from typing import Optional, Iterable, Callable, List
+from typing import Optional, Iterable, Callable, List, Union, Type
 import torch
 
+from data_gradients.feature_extractors import AbstractFeatureExtractor
 from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
-from data_gradients.config.utils import load_report_feature_extractors
 from data_gradients.batch_processors.detection import DetectionBatchProcessor
 from data_gradients.config.data.data_config import DetectionDataConfig
 from data_gradients.config.data.typing import SupportedDataType
@@ -22,6 +21,16 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         val_data: Optional[Iterable] = None,
         report_subtitle: Optional[str] = None,
         config_path: Optional[str] = None,
+        feature_extractors: Optional[
+            Union[
+                List[
+                    Union[str, AbstractFeatureExtractor, Type[AbstractFeatureExtractor]]
+                ],
+                str,
+                AbstractFeatureExtractor,
+                Type[AbstractFeatureExtractor],
+            ]
+        ] = None,
         log_dir: Optional[str] = None,
         use_cache: bool = False,
         class_names: Optional[List[str]] = None,
@@ -44,6 +53,7 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         :param train_data:              Iterable object contains images and labels of the training dataset
         :param val_data:                Iterable object contains images and labels of the validation dataset
         :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used.
+        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used.
         :param log_dir:                 Directory where to save the logs. By default uses the current working directory
         :param batches_early_stop:      Maximum number of batches to run in training (early stop)
         :param use_cache:               Whether to use cache or not for the configuration of the data.
@@ -54,6 +64,8 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         :param bbox_format:             Format of the bounding boxes. 'xyxy', 'xywh' or 'cxcywh'
         :param n_image_channels:        Number of channels for each image in the dataset
         """
+        assert feature_extractors is None or config_path is None, "`feature_extractors` and `config_path` cannot be specified at the same time"
+
         data_config = DetectionDataConfig(
             use_cache=use_cache,
             images_extractor=images_extractor,
@@ -76,12 +88,11 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
                 raise RuntimeError(f"You defined `class_names_to_use` with classes that are not listed in `class_names`: {invalid_class_names_to_use}")
         class_names_to_use = class_names_to_use or class_names
 
-        # Resolve `config_dir` and `config_name` defining the feature extractors.
-        if config_path is None:
-            config_dir, config_name = None, "detection"
-        else:
-            config_path = os.path.abspath(config_path)
-            config_dir, config_name = os.path.dirname(config_path), os.path.basename(config_path).split(".")[0]
+        grouped_feature_extractors = self._get_grouped_feature_extractors(
+            default_config_name="detection",
+            config_path=config_path,
+            feature_extractors=feature_extractors,
+        )
 
         batch_processor = DetectionBatchProcessor(
             data_config=data_config,
@@ -90,8 +101,6 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
             class_names_to_use=class_names_to_use,
         )
 
-        feature_extractors = load_report_feature_extractors(config_name=config_name, config_dir=config_dir)
-
         super().__init__(
             data_config=data_config,
             report_title=report_title,
@@ -99,7 +108,7 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
             train_data=train_data,
             val_data=val_data,
             batch_processor=batch_processor,
-            grouped_feature_extractors=feature_extractors,
+            grouped_feature_extractors=grouped_feature_extractors,
             log_dir=log_dir,
             batches_early_stop=batches_early_stop,
         )

--- a/src/data_gradients/managers/detection_manager.py
+++ b/src/data_gradients/managers/detection_manager.py
@@ -1,11 +1,12 @@
-from typing import Optional, Iterable, Callable, List, Union, Type
+from typing import Optional, Iterable, Callable, List
+
 import torch
 
-from data_gradients.feature_extractors import AbstractFeatureExtractor
-from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.batch_processors.detection import DetectionBatchProcessor
 from data_gradients.config.data.data_config import DetectionDataConfig
-from data_gradients.config.data.typing import SupportedDataType
+from data_gradients.config.data.typing import SupportedDataType, FeatureExtractorsType
+from data_gradients.config.utils import get_grouped_feature_extractors
+from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 
 
 class DetectionAnalysisManager(AnalysisManagerAbstract):
@@ -21,16 +22,7 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         val_data: Optional[Iterable] = None,
         report_subtitle: Optional[str] = None,
         config_path: Optional[str] = None,
-        feature_extractors: Optional[
-            Union[
-                List[
-                    Union[str, AbstractFeatureExtractor, Type[AbstractFeatureExtractor]]
-                ],
-                str,
-                AbstractFeatureExtractor,
-                Type[AbstractFeatureExtractor],
-            ]
-        ] = None,
+        feature_extractors: Optional[FeatureExtractorsType] = None,
         log_dir: Optional[str] = None,
         use_cache: bool = False,
         class_names: Optional[List[str]] = None,
@@ -53,8 +45,10 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         :param n_classes:               Number of classes. Mutually exclusive with `class_names`.
         :param train_data:              Iterable object contains images and labels of the training dataset
         :param val_data:                Iterable object contains images and labels of the validation dataset
-        :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used.
-        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used.
+        :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used. Mutually exclusive
+                                        with feature_extractors
+        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used. Mutually exclusive
+                                        with config_path
         :param log_dir:                 Directory where to save the logs. By default uses the current working directory
         :param batches_early_stop:      Maximum number of batches to run in training (early stop)
         :param use_cache:               Whether to use cache or not for the configuration of the data.
@@ -66,7 +60,8 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         :param n_image_channels:        Number of channels for each image in the dataset
         :param remove_plots_after_report:  Delete the plots from the report directory after the report is generated. By default, True
         """
-        assert feature_extractors is None or config_path is None, "`feature_extractors` and `config_path` cannot be specified at the same time"
+        if feature_extractors is not None and config_path is not None:
+            raise RuntimeError("`feature_extractors` and `config_path` cannot be specified at the same time")
 
         data_config = DetectionDataConfig(
             use_cache=use_cache,
@@ -90,7 +85,7 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
                 raise RuntimeError(f"You defined `class_names_to_use` with classes that are not listed in `class_names`: {invalid_class_names_to_use}")
         class_names_to_use = class_names_to_use or class_names
 
-        grouped_feature_extractors = self._get_grouped_feature_extractors(
+        grouped_feature_extractors = get_grouped_feature_extractors(
             default_config_name="detection",
             config_path=config_path,
             feature_extractors=feature_extractors,

--- a/src/data_gradients/managers/segmentation_manager.py
+++ b/src/data_gradients/managers/segmentation_manager.py
@@ -1,9 +1,8 @@
-import os
-from typing import Optional, Iterable, Callable, List
+from typing import Optional, Iterable, Callable, List, Union, Type
 import torch
 
+from data_gradients.feature_extractors import AbstractFeatureExtractor
 from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
-from data_gradients.config.utils import load_report_feature_extractors
 from data_gradients.batch_processors.segmentation import SegmentationBatchProcessor
 from data_gradients.config.data.data_config import SegmentationDataConfig
 from data_gradients.config.data.typing import SupportedDataType
@@ -23,6 +22,16 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         val_data: Optional[Iterable] = None,
         report_subtitle: Optional[str] = None,
         config_path: Optional[str] = None,
+        feature_extractors: Optional[
+            Union[
+                List[
+                    Union[str, AbstractFeatureExtractor, Type[AbstractFeatureExtractor]]
+                ],
+                str,
+                AbstractFeatureExtractor,
+                Type[AbstractFeatureExtractor],
+            ]
+        ] = None,
         log_dir: Optional[str] = None,
         use_cache: bool = False,
         class_names: Optional[List[str]] = None,
@@ -45,6 +54,7 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         :param train_data:              Iterable object contains images and labels of the training dataset
         :param val_data:                Iterable object contains images and labels of the validation dataset
         :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used.
+        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used.
         :param log_dir:                 Directory where to save the logs. By default uses the current working directory
         :param id_to_name:              Class ID to class names mapping (Dictionary)
         :param batches_early_stop:      Maximum number of batches to run in training (early stop)
@@ -54,6 +64,8 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         :param num_image_channels:      Number of channels for each image in the dataset
         :param threshold_soft_labels:   Threshold for converting soft labels to binary labels
         """
+        assert feature_extractors is None or config_path is None, "`feature_extractors` and `config_path` cannot be specified at the same time"
+
         data_config = SegmentationDataConfig(use_cache=use_cache, images_extractor=images_extractor, labels_extractor=labels_extractor)
 
         # Check values of `n_classes` and `class_names` to define `class_names`.
@@ -70,12 +82,11 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
                 raise RuntimeError(f"You defined `class_names_to_use` with classes that are not listed in `class_names`: {invalid_class_names_to_use}")
         class_names_to_use = class_names_to_use or class_names
 
-        # Resolve `config_dir` and `config_name` defining the feature extractors.
-        if config_path is None:
-            config_dir, config_name = None, "segmentation"
-        else:
-            config_path = os.path.abspath(config_path)
-            config_dir, config_name = os.path.dirname(config_path), os.path.basename(config_path).split(".")[0]
+        grouped_feature_extractors = self._get_grouped_feature_extractors(
+            default_config_name="segmentation",
+            config_path=config_path,
+            feature_extractors=feature_extractors,
+        )
 
         batch_processor = SegmentationBatchProcessor(
             data_config=data_config,
@@ -84,8 +95,6 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
             n_image_channels=num_image_channels,
             threshold_value=threshold_soft_labels,
         )
-
-        grouped_feature_extractors = load_report_feature_extractors(config_name=config_name, config_dir=config_dir)
 
         super().__init__(
             data_config=data_config,

--- a/src/data_gradients/managers/segmentation_manager.py
+++ b/src/data_gradients/managers/segmentation_manager.py
@@ -1,11 +1,11 @@
-from typing import Optional, Iterable, Callable, List, Union, Type
+from typing import Optional, Iterable, Callable, List
 import torch
 
-from data_gradients.feature_extractors import AbstractFeatureExtractor
+from data_gradients.config.utils import get_grouped_feature_extractors
 from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.batch_processors.segmentation import SegmentationBatchProcessor
 from data_gradients.config.data.data_config import SegmentationDataConfig
-from data_gradients.config.data.typing import SupportedDataType
+from data_gradients.config.data.typing import SupportedDataType, FeatureExtractorsType
 
 
 class SegmentationAnalysisManager(AnalysisManagerAbstract):
@@ -22,16 +22,7 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         val_data: Optional[Iterable] = None,
         report_subtitle: Optional[str] = None,
         config_path: Optional[str] = None,
-        feature_extractors: Optional[
-            Union[
-                List[
-                    Union[str, AbstractFeatureExtractor, Type[AbstractFeatureExtractor]]
-                ],
-                str,
-                AbstractFeatureExtractor,
-                Type[AbstractFeatureExtractor],
-            ]
-        ] = None,
+        feature_extractors: Optional[FeatureExtractorsType] = None,
         log_dir: Optional[str] = None,
         use_cache: bool = False,
         class_names: Optional[List[str]] = None,
@@ -54,8 +45,10 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         :param n_classes:               Number of classes. Mutually exclusive with `class_names`. If set, `class_names` will be a list of `class_ids`.
         :param train_data:              Iterable object contains images and labels of the training dataset
         :param val_data:                Iterable object contains images and labels of the validation dataset
-        :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used.
-        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used.
+        :param config_path:             Full path the hydra configuration file. If None, the default configuration will be used. Mutually exclusive
+                                        with feature_extractors
+        :param feature_extractors:      One or more feature extractors to use. If None, the default configuration will be used. Mutually exclusive
+                                        with config_path
         :param log_dir:                 Directory where to save the logs. By default uses the current working directory
         :param id_to_name:              Class ID to class names mapping (Dictionary)
         :param batches_early_stop:      Maximum number of batches to run in training (early stop)
@@ -66,7 +59,8 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         :param threshold_soft_labels:   Threshold for converting soft labels to binary labels
         :param remove_plots_after_report:  Delete the plots from the report directory after the report is generated. By default, True
         """
-        assert feature_extractors is None or config_path is None, "`feature_extractors` and `config_path` cannot be specified at the same time"
+        if feature_extractors is not None and config_path is not None:
+            raise RuntimeError("`feature_extractors` and `config_path` cannot be specified at the same time")
 
         data_config = SegmentationDataConfig(use_cache=use_cache, images_extractor=images_extractor, labels_extractor=labels_extractor)
 
@@ -84,7 +78,7 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
                 raise RuntimeError(f"You defined `class_names_to_use` with classes that are not listed in `class_names`: {invalid_class_names_to_use}")
         class_names_to_use = class_names_to_use or class_names
 
-        grouped_feature_extractors = self._get_grouped_feature_extractors(
+        grouped_feature_extractors = get_grouped_feature_extractors(
             default_config_name="segmentation",
             config_path=config_path,
             feature_extractors=feature_extractors,


### PR DESCRIPTION
This allows the user to pass feature extractors (one or more. as a sting, type, or instance) when initializing the Manager.
That way, the user can choose a small subset of FEs without manipulating the YAML 