### PR TITLE
Fix Average Brightness

### DIFF
--- a/src/data_gradients/feature_extractors/common/image_average_brightness.py
+++ b/src/data_gradients/feature_extractors/common/image_average_brightness.py
@@ -39,10 +39,7 @@ class ImagesAverageBrightness(AbstractFeatureExtractor):
         else:
             raise ValueError(f"Unknown image format {sample.image_format}")
 
-        if sample.split == "val":
-            self.data.append({"split": sample.split, "brightness": 123})
-        else:
-            self.data.append({"split": sample.split, "brightness": brightness})
+        self.data.append({"split": sample.split, "brightness": brightness})
 
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)

--- a/src/data_gradients/visualize/seaborn_renderer.py
+++ b/src/data_gradients/visualize/seaborn_renderer.py
@@ -349,14 +349,15 @@ class SeabornRenderer(PlotRenderer):
         if options.labels_name is not None:
             ax.legend(title=options.labels_name)
 
-        # Write the values on the graph
-        y_ticklabels_fontsize = ax.get_yticklabels()[0].get_fontsize()
-        for container in ax.containers:
-            for bar in container:
-                width = bar.get_width()
-                height = bar.get_y() + bar.get_height() / 2
-                width_rounded = round(width, 1) if width >= 0.1 else float(f"{width:.1e}")
-                ax.text(width + 0.5, height, f"{width_rounded}%", ha="left", va="center", fontsize=y_ticklabels_fontsize)
+        if options.show_values:
+            # Write the values on the graph
+            y_ticklabels_fontsize = ax.get_yticklabels()[0].get_fontsize()
+            for container in ax.containers:
+                for bar in container:
+                    width = bar.get_width()
+                    height = bar.get_y() + bar.get_height() / 2
+                    width_rounded = round(width, 1) if width >= 0.1 else float(f"{width:.1e}")
+                    ax.text(width + 0.5, height, f"{width_rounded}%", ha="left", va="center", fontsize=y_ticklabels_fontsize)
 
         if options.log_scale is True:
             ax.set_yscale("log")
@@ -368,9 +369,6 @@ class SeabornRenderer(PlotRenderer):
                 options.x_ticks_rotation = 90
             elif n_unique > 10:
                 options.x_ticks_rotation = 45
-
-        if options.show_values:
-            self._show_values(ax)
 
         self._set_ticks_rotation(ax, options.x_ticks_rotation, options.y_ticks_rotation)
 


### PR DESCRIPTION
If a split is made of a single value, the KDE and HIST plots don't work (they expect a distribution with >1 different value.
This sometimes happens with image brightness if the image was normalized to the same value throughout the dataset.

To still show results in that specific case, we will now show a barplot when either of the split is made of a single value (i.e. when it cannot be shown as KDE or HIST).

Note that this is an edge case that should not be common at all.

Example
<img width="786" alt="image" src="https://github.com/Deci-AI/data-gradients/assets/35190946/6d1dcb03-54c0-40d0-bd47-d50d87daaf7f">
