### PR TITLE
Feature/sg 890 Quickfix for high num_classes

### DIFF
--- a/src/data_gradients/batch_processors/formatters/detection.py
+++ b/src/data_gradients/batch_processors/formatters/detection.py
@@ -57,6 +57,10 @@ class DetectionBatchFormatter(BatchFormatter):
             - labels: List of bounding boxes, each of shape (N_i, 5 [label_xyxy]) with N_i being the number of bounding boxes with class_id in class_ids
         """
 
+        # Might happen if the user passes tensors as [N, 5] with N=1; If poorly coded, the Dataset may instead return a [5] tensor
+        if labels.numel() == 0:
+            labels = torch.zeros((0, 5))
+
         # If the label is of shape [N, 5] we can assume that it represents the targets of a single sample (class_name + 4 bbox coordinates)
         if labels.ndim == 2 and labels.shape[1] == 5:
             images = images.unsqueeze(0)
@@ -75,6 +79,9 @@ class DetectionBatchFormatter(BatchFormatter):
         if 0 <= images.min() and images.max() <= 1:
             images *= 255
             images = images.to(torch.uint8)
+
+        if labels.numel() == 0:
+            return images, labels
 
         labels = self.convert_to_label_xyxy(
             annotated_bboxes=labels,

--- a/src/data_gradients/batch_processors/formatters/detection.py
+++ b/src/data_gradients/batch_processors/formatters/detection.py
@@ -57,10 +57,6 @@ class DetectionBatchFormatter(BatchFormatter):
             - labels: List of bounding boxes, each of shape (N_i, 5 [label_xyxy]) with N_i being the number of bounding boxes with class_id in class_ids
         """
 
-        # Might happen if the user passes tensors as [N, 5] with N=1; If poorly coded, the Dataset may instead return a [5] tensor
-        if labels.numel() == 0:
-            labels = torch.zeros((0, 5))
-
         # If the label is of shape [N, 5] we can assume that it represents the targets of a single sample (class_name + 4 bbox coordinates)
         if labels.ndim == 2 and labels.shape[1] == 5:
             images = images.unsqueeze(0)
@@ -79,9 +75,6 @@ class DetectionBatchFormatter(BatchFormatter):
         if 0 <= images.min() and images.max() <= 1:
             images *= 255
             images = images.to(torch.uint8)
-
-        if labels.numel() == 0:
-            return images, labels
 
         labels = self.convert_to_label_xyxy(
             annotated_bboxes=labels,

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
@@ -34,7 +34,7 @@ class DetectionBoundingBoxArea(AbstractFeatureExtractor):
         # Height of the plot is proportional to the number of classes
         n_unique = len(df["class_name"].unique())
         figsize_x = 10
-        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
 
         max_area = min(100, df["relative_bbox_area"].max())
 

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
@@ -31,7 +31,13 @@ class DetectionBoundingBoxArea(AbstractFeatureExtractor):
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)
 
+        # Height of the plot is proportional to the number of classes
+        n_unique = len(df["class_name"].unique())
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
+
         max_area = min(100, df["relative_bbox_area"].max())
+
         plot_options = ViolinPlotOptions(
             x_label_key="relative_bbox_area",
             x_label_name="Bounding Box Area (in % of image)",
@@ -42,6 +48,7 @@ class DetectionBoundingBoxArea(AbstractFeatureExtractor):
             x_ticks_rotation=None,
             labels_key="split",
             x_lim=(0, max_area),
+            figsize=(figsize_x, figsize_y),
             bandwidth=0.4,
         )
 

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
@@ -97,8 +97,7 @@ class DetectionBoundingBoxIoU(AbstractFeatureExtractor):
 
         # Height of the plot is proportional to the number of classes
         figsize_x = min(max(10, len(bins)), 25)
-        figsize_y = int(num_classes * 0.3) + 4
-        figsize_y = min(max(6, figsize_y), 90)
+        figsize_y = min(max(6, int(num_classes * 0.3)), 175)
 
         plot_options = HeatmapOptions(
             xticklabels=xticklabels,

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
@@ -74,7 +74,7 @@ class DetectionBoundingBoxIoU(AbstractFeatureExtractor):
         data = {}
         json = {}
 
-        splits = df["split"].unique()
+        splits = sorted(df["split"].unique())
         for split in splits:
             counts = self._compute_cumulative_counts_at_thresholds(df[df["split"] == split], class_names, self.num_bins)
 
@@ -95,6 +95,11 @@ class DetectionBoundingBoxIoU(AbstractFeatureExtractor):
             self._show_plot = False
             return Feature(data=None, plot_options=None, json={})
 
+        # Height of the plot is proportional to the number of classes
+        figsize_x = min(max(10, len(bins)), 25)
+        figsize_y = int(num_classes * 0.3) + 4
+        figsize_y = min(max(6, figsize_y), 90)
+
         plot_options = HeatmapOptions(
             xticklabels=xticklabels,
             yticklabels=class_names + ["All classes"],
@@ -106,8 +111,7 @@ class DetectionBoundingBoxIoU(AbstractFeatureExtractor):
             annot=True,
             title=self.title,
             square=True,
-            # Height of the plot is proportional to the number of classes
-            figsize=(10, (int(num_classes * 0.3) + 4) * len(splits)),
+            figsize=(figsize_x, figsize_y),
             tight_layout=True,
             x_ticks_rotation=90,
         )

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
@@ -34,6 +34,11 @@ class DetectionClassFrequency(AbstractFeatureExtractor):
         split_sums = df_class_count.groupby("split")["n_appearance"].sum()
         df_class_count["frequency"] = 100 * (df_class_count["n_appearance"] / df_class_count["split"].map(split_sums))
 
+        # Height of the plot is proportional to the number of classes
+        n_unique = len(df_class_count["class_name"].unique())
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
+
         plot_options = BarPlotOptions(
             x_label_key="frequency",
             x_label_name="Frequency",
@@ -41,6 +46,7 @@ class DetectionClassFrequency(AbstractFeatureExtractor):
             y_label_name="Class",
             order_key="class_id",
             title=self.title,
+            figsize=(figsize_x, figsize_y),
             x_ticks_rotation=None,
             labels_key="split",
             orient="h",

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
@@ -37,7 +37,7 @@ class DetectionClassFrequency(AbstractFeatureExtractor):
         # Height of the plot is proportional to the number of classes
         n_unique = len(df_class_count["class_name"].unique())
         figsize_x = 10
-        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
 
         plot_options = BarPlotOptions(
             x_label_key="frequency",

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
@@ -38,7 +38,7 @@ class DetectionClassesPerImageCount(AbstractFeatureExtractor):
         # Height of the plot is proportional to the number of classes
         n_unique = len(df_class_count["class_name"].unique())
         figsize_x = 10
-        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
 
         plot_options = ViolinPlotOptions(
             x_label_key="n_appearance",

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
@@ -35,12 +35,11 @@ class DetectionClassesPerImageCount(AbstractFeatureExtractor):
         # TODO: check this
         df_class_count = df.groupby(["class_name", "class_id", "sample_id", "split"]).size().reset_index(name="n_appearance")
 
+        # Height of the plot is proportional to the number of classes
         n_unique = len(df_class_count["class_name"].unique())
-        factor = max(1.0, n_unique / 10.0)
-        figsize_x = min(max(10, int(10 * factor)), 30)
-        figsize_y = min(max(6, int(6 * factor / 2)), 9)
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 90)
 
-        print("factor: ", figsize_x, figsize_y)
         plot_options = ViolinPlotOptions(
             x_label_key="n_appearance",
             x_label_name="Number of class instance per Image",

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
@@ -35,6 +35,12 @@ class DetectionClassesPerImageCount(AbstractFeatureExtractor):
         # TODO: check this
         df_class_count = df.groupby(["class_name", "class_id", "sample_id", "split"]).size().reset_index(name="n_appearance")
 
+        n_unique = len(df_class_count["class_name"].unique())
+        factor = max(1.0, n_unique / 10.0)
+        figsize_x = min(max(10, int(10 * factor)), 30)
+        figsize_y = min(max(6, int(6 * factor / 2)), 9)
+
+        print("factor: ", figsize_x, figsize_y)
         plot_options = ViolinPlotOptions(
             x_label_key="n_appearance",
             x_label_name="Number of class instance per Image",
@@ -44,6 +50,7 @@ class DetectionClassesPerImageCount(AbstractFeatureExtractor):
             title=self.title,
             x_lim=(0, df_class_count["n_appearance"].max() * 1.2),
             bandwidth=0.4,
+            figsize=(figsize_x, figsize_y),
             x_ticks_rotation=None,
             labels_key="split",
         )

--- a/src/data_gradients/feature_extractors/segmentation/bounding_boxes_area.py
+++ b/src/data_gradients/feature_extractors/segmentation/bounding_boxes_area.py
@@ -35,6 +35,11 @@ class SegmentationBoundingBoxArea(AbstractFeatureExtractor):
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)
 
+        # Height of the plot is proportional to the number of classes
+        n_unique = len(df["class_name"].unique())
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
+
         max_area = min(100, df["bbox_area"].max())
         plot_options = ViolinPlotOptions(
             x_label_key="bbox_area",
@@ -43,6 +48,7 @@ class SegmentationBoundingBoxArea(AbstractFeatureExtractor):
             y_label_name="Class",
             order_key="class_id",
             title=self.title,
+            figsize=(figsize_x, figsize_y),
             x_lim=(0, max_area),
             x_ticks_rotation=None,
             labels_key="split",

--- a/src/data_gradients/feature_extractors/segmentation/classes_frequency.py
+++ b/src/data_gradients/feature_extractors/segmentation/classes_frequency.py
@@ -34,6 +34,11 @@ class SegmentationClassFrequency(AbstractFeatureExtractor):
         split_sums = df_class_count.groupby("split")["n_appearance"].sum()
         df_class_count["frequency"] = 100 * (df_class_count["n_appearance"] / df_class_count["split"].map(split_sums))
 
+        # Height of the plot is proportional to the number of classes
+        n_unique = len(df_class_count["class_name"].unique())
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
+
         plot_options = BarPlotOptions(
             x_label_key="frequency",
             x_label_name="Frequency",
@@ -41,6 +46,7 @@ class SegmentationClassFrequency(AbstractFeatureExtractor):
             y_label_name="Class",
             order_key="class_id",
             title=self.title,
+            figsize=(figsize_x, figsize_y),
             x_ticks_rotation=None,
             labels_key="split",
             orient="h",

--- a/src/data_gradients/feature_extractors/segmentation/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/segmentation/classes_frequency_per_image.py
@@ -36,6 +36,11 @@ class SegmentationClassesPerImageCount(AbstractFeatureExtractor):
 
         max_n_appearance = df_class_count["n_appearance"].max()
 
+        # Height of the plot is proportional to the number of classes
+        n_unique = len(df_class_count["class_name"].unique())
+        figsize_x = 10
+        figsize_y = min(max(6, int(n_unique * 0.3)), 175)
+
         plot_options = ViolinPlotOptions(
             x_label_key="n_appearance",
             x_label_name="Number of class instance per Image",
@@ -44,6 +49,7 @@ class SegmentationClassesPerImageCount(AbstractFeatureExtractor):
             order_key="class_id",
             title=self.title,
             x_lim=(0, max_n_appearance * 1.2),  # Cut the max_x at 120% of the highest max n_appearance to increase readability
+            figsize=(figsize_x, figsize_y),
             bandwidth=0.4,
             x_ticks_rotation=None,
             labels_key="split",

--- a/src/data_gradients/managers/abstract_manager.py
+++ b/src/data_gradients/managers/abstract_manager.py
@@ -159,7 +159,7 @@ class AnalysisManagerAbstract(abc.ABC):
                 if f is not None:
                     image_name = feature_extractor.__class__.__name__ + ".png"
                     image_path = os.path.join(self.summary_writer.archive_dir, image_name)
-                    f.savefig(image_path, dpi=300)
+                    f.savefig(image_path, dpi=200)
                     images_created.append(image_path)
                 else:
                     image_path = None

--- a/src/data_gradients/visualize/seaborn_renderer.py
+++ b/src/data_gradients/visualize/seaborn_renderer.py
@@ -378,17 +378,18 @@ class SeabornRenderer(PlotRenderer):
 
     def _render_heatmap(self, data: Mapping[str, np.ndarray], options: HeatmapOptions) -> plt.Figure:
 
-        fig, axes = plt.subplots(nrows=len(data), ncols=1, figsize=options.figsize, tight_layout=options.tight_layout)
+        fig, axes = plt.subplots(nrows=1, ncols=len(data), figsize=options.figsize, tight_layout=options.tight_layout)
         fig.subplots_adjust()
 
         for i, (key, heatmap) in enumerate(data.items()):
             ax = axes[i] if len(data) > 1 else axes
+            cbar = options.cbar if i + 1 == len(data) else False
             heatmap_args = dict(
                 data=heatmap,
                 xticklabels=options.xticklabels,
                 yticklabels=options.yticklabels,
                 annot=options.annot,
-                cbar=options.cbar,
+                cbar=cbar,
                 cbar_kws={"shrink": 0.5},
                 square=options.square,
                 cmap=options.cmap,


### PR DESCRIPTION
This fix does not fully solve the issue with high number of classes but already covers most of it. 
This PR aims at increasing readability for up to 100-200 classes (see screenshots).

What I did
- Increasing the fig size up to a certain value (to avoid having too heavy pdf + to avoid crashes that can happen if image size is too bug)
- Changing the IoU plot to concatenate the splits horizontally instead of vertically.

Notes
- It may be a bit harder to read when there are too many classes, but the user can zoom in (the resolution allows it), and I think it is better like that compared to limiting the number of classes to ~20.
- We may want to set a lower limit to the y_size to avoid having such a narrow plot, but I personally think it is fine like that thanks to the zoom

- **It will be combined with the next PR which will add an option to only see the topk classes (most frequent, least frequent, outliers, ...)**.


### Screenshots
<img width="688" alt="image" src="https://github.com/Deci-AI/data-gradients/assets/35190946/155d0d95-5d87-4820-9bc9-c889946e2527">
<img width="688" alt="image" src="https://github.com/Deci-AI/data-gradients/assets/35190946/5bce023f-4a9f-4746-b766-0e76ac812e53">
<img width="688" alt="image" src="https://github.com/Deci-AI/data-gradients/assets/35190946/0c885f3d-7225-46c9-aea2-1535906552b4">
