### PR TITLE
show long class_name 

### DIFF
--- a/src/data_gradients/batch_processors/formatters/detection.py
+++ b/src/data_gradients/batch_processors/formatters/detection.py
@@ -57,6 +57,10 @@ class DetectionBatchFormatter(BatchFormatter):
             - labels: List of bounding boxes, each of shape (N_i, 5 [label_xyxy]) with N_i being the number of bounding boxes with class_id in class_ids
         """
 
+        # Might happen if the user passes tensors as [N, 5] with N=1; If poorly coded, the Dataset may instead return a [5] tensor
+        if labels.numel() == 0:
+            labels = torch.zeros((0, 5))
+
         # If the label is of shape [N, 5] we can assume that it represents the targets of a single sample (class_name + 4 bbox coordinates)
         if labels.ndim == 2 and labels.shape[1] == 5:
             images = images.unsqueeze(0)
@@ -75,6 +79,9 @@ class DetectionBatchFormatter(BatchFormatter):
         if 0 <= images.min() and images.max() <= 1:
             images *= 255
             images = images.to(torch.uint8)
+
+        if labels.numel() == 0:
+            return images, labels
 
         labels = self.convert_to_label_xyxy(
             annotated_bboxes=labels,

--- a/src/data_gradients/batch_processors/formatters/detection.py
+++ b/src/data_gradients/batch_processors/formatters/detection.py
@@ -57,10 +57,6 @@ class DetectionBatchFormatter(BatchFormatter):
             - labels: List of bounding boxes, each of shape (N_i, 5 [label_xyxy]) with N_i being the number of bounding boxes with class_id in class_ids
         """
 
-        # Might happen if the user passes tensors as [N, 5] with N=1; If poorly coded, the Dataset may instead return a [5] tensor
-        if labels.numel() == 0:
-            labels = torch.zeros((0, 5))
-
         # If the label is of shape [N, 5] we can assume that it represents the targets of a single sample (class_name + 4 bbox coordinates)
         if labels.ndim == 2 and labels.shape[1] == 5:
             images = images.unsqueeze(0)
@@ -79,9 +75,6 @@ class DetectionBatchFormatter(BatchFormatter):
         if 0 <= images.min() and images.max() <= 1:
             images *= 255
             images = images.to(torch.uint8)
-
-        if labels.numel() == 0:
-            return images, labels
 
         labels = self.convert_to_label_xyxy(
             annotated_bboxes=labels,

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_area.py
@@ -50,6 +50,7 @@ class DetectionBoundingBoxArea(AbstractFeatureExtractor):
             x_lim=(0, max_area),
             figsize=(figsize_x, figsize_y),
             bandwidth=0.4,
+            tight_layout=True,
         )
 
         json = dict(

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency.py
@@ -50,6 +50,7 @@ class DetectionClassFrequency(AbstractFeatureExtractor):
             x_ticks_rotation=None,
             labels_key="split",
             orient="h",
+            tight_layout=True,
         )
 
         json = dict(

--- a/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/object_detection/classes_frequency_per_image.py
@@ -52,6 +52,7 @@ class DetectionClassesPerImageCount(AbstractFeatureExtractor):
             figsize=(figsize_x, figsize_y),
             x_ticks_rotation=None,
             labels_key="split",
+            tight_layout=True,
         )
 
         json = dict(

--- a/src/data_gradients/feature_extractors/segmentation/bounding_boxes_area.py
+++ b/src/data_gradients/feature_extractors/segmentation/bounding_boxes_area.py
@@ -53,6 +53,7 @@ class SegmentationBoundingBoxArea(AbstractFeatureExtractor):
             x_ticks_rotation=None,
             labels_key="split",
             bandwidth=0.4,
+            tight_layout=True,
         )
         json = dict(train=dict(df[df["split"] == "train"]["bbox_area"].describe()), val=dict(df[df["split"] == "val"]["bbox_area"].describe()))
 

--- a/src/data_gradients/feature_extractors/segmentation/classes_frequency.py
+++ b/src/data_gradients/feature_extractors/segmentation/classes_frequency.py
@@ -50,6 +50,7 @@ class SegmentationClassFrequency(AbstractFeatureExtractor):
             x_ticks_rotation=None,
             labels_key="split",
             orient="h",
+            tight_layout=True,
         )
 
         json = dict(

--- a/src/data_gradients/feature_extractors/segmentation/classes_frequency_per_image.py
+++ b/src/data_gradients/feature_extractors/segmentation/classes_frequency_per_image.py
@@ -53,6 +53,7 @@ class SegmentationClassesPerImageCount(AbstractFeatureExtractor):
             bandwidth=0.4,
             x_ticks_rotation=None,
             labels_key="split",
+            tight_layout=True,
         )
 
         json = dict(

--- a/src/data_gradients/visualize/seaborn_renderer.py
+++ b/src/data_gradients/visualize/seaborn_renderer.py
@@ -65,8 +65,6 @@ class SeabornRenderer(PlotRenderer):
             n_rows = int(np.ceil(_num_images / n_cols))
 
         fig, axs = plt.subplots(nrows=n_rows, ncols=n_cols, figsize=options.figsize, sharey=options.sharey)
-        if options.tight_layout:
-            fig.tight_layout()
         fig.subplots_adjust(top=0.9)
 
         if n_rows == 1 and n_cols == 1:
@@ -109,6 +107,8 @@ class SeabornRenderer(PlotRenderer):
 
             self._set_ticks_rotation(ax_i, options.x_ticks_rotation, options.y_ticks_rotation)
 
+        if options.tight_layout:
+            fig.tight_layout()
         return fig
 
     def _render_histplot(self, df, options: Hist2DPlotOptions) -> plt.Figure:
@@ -125,8 +125,6 @@ class SeabornRenderer(PlotRenderer):
             n_rows = int(np.ceil(_num_images / n_cols))
 
         fig, axs = plt.subplots(nrows=n_rows, ncols=n_cols, figsize=options.figsize, sharey=options.sharey)
-        if options.tight_layout:
-            fig.tight_layout()
         fig.subplots_adjust(top=0.9)
 
         if n_rows == 1 and n_cols == 1:
@@ -181,6 +179,8 @@ class SeabornRenderer(PlotRenderer):
 
             self._set_ticks_rotation(ax_i, options.x_ticks_rotation, options.y_ticks_rotation)
 
+        if options.tight_layout:
+            fig.tight_layout()
         return fig
 
     def _render_kdeplot(self, df, options: KDEPlotOptions) -> plt.Figure:
@@ -197,8 +197,6 @@ class SeabornRenderer(PlotRenderer):
             n_rows = int(np.ceil(_num_images / n_cols))
 
         fig, axs = plt.subplots(nrows=n_rows, ncols=n_cols, figsize=options.figsize, sharey=options.sharey)
-        if options.tight_layout:
-            fig.tight_layout()
         fig.subplots_adjust(top=0.9)
 
         if n_rows == 1 and n_cols == 1:
@@ -255,12 +253,12 @@ class SeabornRenderer(PlotRenderer):
 
             self._set_ticks_rotation(ax_i, options.x_ticks_rotation, options.y_ticks_rotation)
 
+        if options.tight_layout:
+            fig.tight_layout()
         return fig
 
     def _render_violinplot(self, df, options: ViolinPlotOptions) -> plt.Figure:
         fig, ax = plt.subplots(nrows=1, ncols=1, figsize=options.figsize)
-        if options.tight_layout:
-            fig.tight_layout()
         fig.subplots_adjust(top=0.9)
 
         plot_args = dict(
@@ -304,13 +302,12 @@ class SeabornRenderer(PlotRenderer):
                 options.x_ticks_rotation = 45
 
         self._set_ticks_rotation(ax, options.x_ticks_rotation, options.y_ticks_rotation)
-
+        if options.tight_layout:
+            fig.tight_layout()
         return fig
 
     def _render_barplot(self, df, options: BarPlotOptions) -> plt.Figure:
         fig, ax = plt.subplots(nrows=1, ncols=1, figsize=options.figsize)
-        if options.tight_layout:
-            fig.tight_layout()
         fig.subplots_adjust(top=0.9)
 
         barplot_args = dict(
@@ -372,6 +369,8 @@ class SeabornRenderer(PlotRenderer):
 
         self._set_ticks_rotation(ax, options.x_ticks_rotation, options.y_ticks_rotation)
 
+        if options.tight_layout:
+            fig.tight_layout()
         return fig
 
     def _render_heatmap(self, data: Mapping[str, np.ndarray], options: HeatmapOptions) -> plt.Figure:


### PR DESCRIPTION
Apparently, fig.tight_layout() should be called at the end, otherwise it does not help with the names being too long..

Now this would look like this (with dummy names)
<img width="476" alt="image" src="https://github.com/Deci-AI/data-gradients/assets/35190946/dc8f31f3-7f52-40a8-84cf-12814a0e6622">
