### PR TITLE
Drop-in replacement of appdirs to platformdirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ hydra-core>=1.2.0
 omegaconf>=2.2.3
 pygments>=2.13.0
 tqdm>=4.64.1
-appdirs>=1.4.4
+platformdirs>=2.5.2
 opencv-python
 Pillow
 tensorboard

--- a/src/data_gradients/config/data/data_config.py
+++ b/src/data_gradients/config/data/data_config.py
@@ -1,7 +1,8 @@
 import os
 import logging
+
+import platformdirs
 import torch
-import appdirs
 from abc import ABC
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Callable, Union
@@ -31,7 +32,7 @@ class DataConfig(ABC):
     images_extractor: Union[None, str, Callable[[SupportedDataType], torch.Tensor]] = None
     labels_extractor: Union[None, str, Callable[[SupportedDataType], torch.Tensor]] = None
 
-    DEFAULT_CACHE_DIR: str = field(default=appdirs.user_cache_dir("DataGradients", "Deci"), init=False)
+    DEFAULT_CACHE_DIR: str = field(default=platformdirs.user_cache_dir("DataGradients", "Deci"), init=False)
 
     @classmethod
     def load_from_json(cls, filename: str, dir_path: Optional[str] = None) -> "DataConfig":


### PR DESCRIPTION
Because https://github.com/ActiveState/appdirs is deprecated and will not be updated