### PR TITLE
fix visualization of normalized images

### DIFF
--- a/src/data_gradients/batch_processors/formatters/segmentation.py
+++ b/src/data_gradients/batch_processors/formatters/segmentation.py
@@ -93,6 +93,11 @@ class SegmentationBatchFormatter(BatchFormatter):
         if 0 <= images.min() and images.max() <= 1:
             images *= 255
             images = images.to(torch.uint8)
+        elif 0 >= images.min(): # images were normalized with some unknown mean and std
+            images -= images.min()
+            images /= images.max()
+            images *= 255
+            images = images.to(torch.uint8)
 
         return images, labels
 


### PR DESCRIPTION
before 
![image](https://github.com/Deci-AI/data-gradients/assets/4509334/1d9aa9b2-f16c-4d85-ac9c-545be3c8beba)

after
![image](https://github.com/Deci-AI/data-gradients/assets/4509334/2eaf4947-6646-47f9-beea-7fdc1b623dbd)
