### PR TITLE
fixed empty page bug

### DIFF
--- a/src/data_gradients/assets/html/doc_template.html
+++ b/src/data_gradients/assets/html/doc_template.html
@@ -323,5 +323,9 @@
         <p class="c0 c2"><span class="c1"></span></p>
         <p class="c0 c2"><span class="c1"></span></p>
     {% endfor %}
+    <div class="alert-box notice">
+        <span><img  src="{{assets.image.info}}" width="40pt" height="25pt">Notice: </span>
+        To better understand how to tackle the data issues highlighted in this report, explore our comprehensive <a href="https://deci.ai/course/profiling-computer-vision-datasets-overview/">course</a> on analyzing computer vision datasets."
+    </div>
 </body>
 </html>

--- a/src/data_gradients/managers/abstract_manager.py
+++ b/src/data_gradients/managers/abstract_manager.py
@@ -266,4 +266,11 @@ class AnalysisManagerAbstract(abc.ABC):
         """
         Formats the feature extractor's description string for a vieable display in HTML.
         """
-        return description.replace("\n", "<br />")
+        if AnalysisManagerAbstract._is_html(description):
+            return description
+        else:
+            return description.replace("\n", "<br />")
+
+    @staticmethod
+    def _is_html(description: str) -> bool:
+        return description.startswith("<") and description.endswith(">")


### PR DESCRIPTION
We have a bug that creates an empty page after the title and before the summary. 

added course link (requested by the marketing team