### PR TITLE
Minor Fixes (IoU, Segmentation resize + improved exception)

### DIFF
--- a/src/data_gradients/feature_extractors/common/image_duplicates.py
+++ b/src/data_gradients/feature_extractors/common/image_duplicates.py
@@ -82,6 +82,12 @@ class ImageDuplicates(AbstractFeatureExtractor):
         self.train_image_dir = train_image_dir
         self.valid_image_dir = valid_image_dir
 
+        if not os.path.isdir(self.train_image_dir):
+            raise FileNotFoundError(f'"Directory `train_image_dir="{self.train_image_dir}"` does not exist.')
+
+        if not os.path.isdir(self.valid_image_dir):
+            raise FileNotFoundError(f'"Directory `valid_image_dir="{self.valid_image_dir}"` does not exist.')
+
     def setup_data_sources(self, train_data: Iterable, val_data: Iterable):
         """
         Called in AbstractManager.__init__

--- a/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
+++ b/src/data_gradients/feature_extractors/object_detection/bounding_boxes_iou.py
@@ -61,7 +61,13 @@ class DetectionBoundingBoxIoU(AbstractFeatureExtractor):
         return counts
 
     def aggregate(self) -> Feature:
-        df = pd.DataFrame(self.data).sort_values(by="class_id")
+        df = pd.DataFrame(self.data)
+
+        if len(df) == 0:
+            self._show_plot = False
+            return Feature(data=None, plot_options=None, json={})
+
+        df = df.sort_values(by="class_id")
 
         bins = np.linspace(0, 1, self.num_bins + 1)
         df["iou_bins"] = np.digitize(df["iou"].values, bins=bins)

--- a/src/data_gradients/feature_extractors/segmentation/classes_heatmap_per_class.py
+++ b/src/data_gradients/feature_extractors/segmentation/classes_heatmap_per_class.py
@@ -26,7 +26,7 @@ class SegmentationClassHeatmap(BaseClassHeatmap):
         mask = sample.mask.transpose((1, 2, 0))
 
         target_size = self.heatmap_shape[1], self.heatmap_shape[0]
-        resized_masks = resize_in_chunks(img=mask.astype(np.uint8), size=target_size, interpolation=cv2.INTER_LINEAR).astype(np.uint8)
+        resized_masks = resize_in_chunks(img=mask.astype(np.uint8), size=target_size, interpolation=cv2.INTER_NEAREST).astype(np.uint8)
         resized_masks = resized_masks.transpose((2, 0, 1))
 
         split_heatmap = self.heatmaps_per_split.get(sample.split, np.zeros((len(sample.class_names), *self.heatmap_shape)))


### PR DESCRIPTION
3 independant minor fixes.
- For duplicates, it just helps crashing sooner if the path are not valid (instead of waiting until end of full analysis...)
- IoU was crashing when there was ALWAYS <=1 bbox
- segmentation; I dont remember if there was a bug due to this, but masks should be reshaped with nearest and not linear,