### PR TITLE
Fix questions display when asking n_channels

### DIFF
--- a/src/data_gradients/dataset_adapters/config/questions.py
+++ b/src/data_gradients/dataset_adapters/config/questions.py
@@ -149,9 +149,12 @@ def ask_option_via_stdin(question: FixedOptionsQuestion, hint: str) -> Any:
     input_message = f"Your selection (Enter the {text_to_blue('corresponding number')}) >>> "
     selected_index = int(ask_via_stdin(question=question.question, optional_description=description, validate_func=validate_func, input_message=input_message))
 
-    potential_values = list(question.options.values())
-    selected_value = potential_values[selected_index]
-    print(f"Great! {text_to_yellow(f'You chose: `{selected_value}`')}")
+    options_descriptions, options_values = zip(*question.options.items())
+
+    selected_description = options_descriptions[selected_index]
+    selected_value = options_values[selected_index]
+
+    print(f"Great! {text_to_yellow(f'You chose: `{selected_description}`')}")
     return selected_value
 
 

--- a/src/data_gradients/dataset_adapters/formatters/base.py
+++ b/src/data_gradients/dataset_adapters/formatters/base.py
@@ -27,7 +27,7 @@ class BatchFormatter(ABC):
         if self._n_image_channels is None:
             question = FixedOptionsQuestion(
                 question="Which dimension corresponds the image channel? ",
-                options={i: images.shape[i] for i in range(len(images.shape))},
+                options={dim: dim for dim in images.shape},
             )
             hint = f"Image shape: {images.shape}"
             self._n_image_channels = self.data_config.get_n_image_channels(question=question, hint=hint)


### PR DESCRIPTION
Before
```
Which dimension corresponds the image channel?

Your tensor is of shape torch.Size([1, 640, 427, 3])
Options:
[0] | 0
[1] | 1
[2] | 2
[3] | 3

Your selection (Enter the corresponding number) >>> 2
Great! You chose: `2`
```


Now
```
How many channels compose your image?

Your tensor is of shape torch.Size([1, 640, 427, 3])
Options:
[0] | 1
[1] | 640
[2] | 427
[3] | 3

Your selection (Enter the corresponding number) >>> 2
Great! You chose: `427`
```

**Motivation**
I fel the old approach was very confusing - weird looking. 
```
Your tensor is of shape torch.Size([1, 3, 640, 427])
Options:
[0] | 0
[1] | 1
[2] | 2
[3] | 3
```
In this case, I intuitively want to press `3` (for RGB) but `3` represents the 3. index, i.e. `427`. 
It's more intuitive to choose the number of channels (e.g. `3` for RGB), than the dimension index