### PR TITLE
Hotfix/sg 000 fix question display n channel

### DIFF
--- a/src/data_gradients/config/detection.yaml
+++ b/src/data_gradients/config/detection.yaml
@@ -7,10 +7,10 @@ report_sections:
       - ImagesAverageBrightness
   - name: Object Detection Features
     features:
-      - DetectionSampleVisualization:
-          n_rows: 3
-          n_cols: 4
-          stack_splits_vertically: True
+#      - DetectionSampleVisualization:
+#          n_rows: 3
+#          n_cols: 4
+#          stack_splits_vertically: True
       - DetectionClassHeatmap:
           n_rows: 6
           n_cols: 2

--- a/src/data_gradients/dataset_adapters/config/data_config.py
+++ b/src/data_gradients/dataset_adapters/config/data_config.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+import numpy as np
 import platformdirs
 import torch
 from abc import ABC
@@ -154,10 +155,7 @@ class DataConfig(ABC):
         if self.class_names_to_use is None:
             self.class_names_to_use = json_dict.get("class_names_to_use")
         if self.image_channels is None:
-            print("IMAGE_CHANNELS: ", self.image_channels)
             self.image_channels = ImageChannels.from_str(json_dict.get("image_channels"))
-        print("DONE")
-        print(self.image_channels)
 
     def get_images_extractor(self, question: Optional[FixedOptionsQuestion] = None, hint: str = "") -> Callable[[SupportedDataType], torch.Tensor]:
         if self.images_extractor is None:
@@ -169,10 +167,43 @@ class DataConfig(ABC):
             self.labels_extractor = question.ask(hint=hint)
         return TensorExtractorResolver.to_callable(tensor_extractor=self.labels_extractor)
 
-    def get_image_channels(self, question: Optional[OpenEndedQuestion] = None, hint: str = "") -> ImageChannels:
+    def get_image_channels(self, image: Union[torch.Tensor, np.ndarray]) -> ImageChannels:
         if self.image_channels is None:
+
+            def _validate_image_channels(channels_str: str) -> bool:
+                if len(channels_str) not in image.shape:
+                    return False
+                try:
+                    ImageChannels.from_str(channels_str=channels_str)
+                    print(f"image_channels_str={channels_str} is valid with {image.shape}")
+                    return True
+                except ValueError:
+                    return False
+
+            question = OpenEndedQuestion(question="Please describe your image channels?", validation=_validate_image_channels)
+            hint = (
+                f"Image Shape: {tuple(image.shape)}\n\n"
+                "Enter the channel format representing your image:\n"
+                "\n"
+                "  > RGB  : Red, Green, Blue\n"
+                "  > BGR  : Blue, Green, Red\n"
+                "  > G    : Grayscale\n"
+                "  > LAB  : Luminance, A and B color channels\n"
+                "\n"
+                "ADDITIONAL CHANNELS?\n"
+                "If your image contains channels other than the standard ones listed above (e.g., Depth, Heat), "
+                "prefix them with 'O'. \n"
+                "For instance:\n"
+                "  > ORGBO: Can represent (Heat, Red, Green, Blue, Depth).\n"
+                "  > OBGR:  Can represent (Alpha, Blue, Green, Red).\n"
+                "  > GO:    Can represent (Gray, Depth).\n\n"
+                f"IMPORTANT: Make sure that your answer represents all the image channels."
+            )
+
             image_channels_str = question.ask(hint=hint)
-            self.image_channels = ImageChannels.from_str(channels_str=image_channels_str)  # TODO: add check
+            print("image_channels_str: ", image_channels_str)
+            self.image_channels = ImageChannels.from_str(channels_str=image_channels_str)
+
         return self.image_channels
 
     def get_is_batch(self, hint: str = "") -> bool:

--- a/src/data_gradients/dataset_adapters/config/questions.py
+++ b/src/data_gradients/dataset_adapters/config/questions.py
@@ -149,9 +149,12 @@ def ask_option_via_stdin(question: FixedOptionsQuestion, hint: str) -> Any:
     input_message = f"Your selection (Enter the {text_to_blue('corresponding number')}) >>> "
     selected_index = int(ask_via_stdin(question=question.question, optional_description=description, validate_func=validate_func, input_message=input_message))
 
-    potential_values = list(question.options.values())
-    selected_value = potential_values[selected_index]
-    print(f"Great! {text_to_yellow(f'You chose: `{selected_value}`')}")
+    options_descriptions, options_values = zip(*question.options.items())
+
+    selected_description = options_descriptions[selected_index]
+    selected_value = options_values[selected_index]
+
+    print(f"Great! {text_to_yellow(f'You chose: `{selected_description}`')}")
     return selected_value
 
 

--- a/src/data_gradients/dataset_adapters/formatters/base.py
+++ b/src/data_gradients/dataset_adapters/formatters/base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 import torch
-from data_gradients.dataset_adapters.config.questions import OpenEndedQuestion
 
 
 class BatchFormatter(ABC):
@@ -25,20 +24,6 @@ class BatchFormatter(ABC):
     def get_n_image_channels(self, images: torch.Tensor) -> int:
         """Get the number of image channels in the batch. If not set yet, it will be asked to the user."""
         if self._n_image_channels is None:
-            question = OpenEndedQuestion(
-                question="Please describe your image channels?",
-            )
-            hint = (
-                f"Image shape: {images.shape}\n\n"
-                "Options:\n"
-                "  - `RGB`\n"
-                "  - `BGR`\n"
-                "  - `L` (Grayscale)\n"
-                "  - `LAB`\n"
-                "Note: If your image has extra channels, you please add a `O` for each of them.\n\n"
-                "E.g. If you have image has 4 (Red, Green, Blue, Depth), you should enter `RGBO` (in the right order!)"
-            )
-
-            image_channels = self.data_config.get_image_channels(question=question, hint=hint)
+            image_channels = self.data_config.get_image_channels(image=images[0])
             self._n_image_channels = len(image_channels)
         return self._n_image_channels

--- a/src/data_gradients/dataset_adapters/formatters/base.py
+++ b/src/data_gradients/dataset_adapters/formatters/base.py
@@ -27,7 +27,7 @@ class BatchFormatter(ABC):
         if self._n_image_channels is None:
             question = FixedOptionsQuestion(
                 question="Which dimension corresponds the image channel? ",
-                options={i: images.shape[i] for i in range(len(images.shape))},
+                options={dim: dim for dim in images.shape},
             )
             hint = f"Image shape: {images.shape}"
             self._n_image_channels = self.data_config.get_n_image_channels(question=question, hint=hint)

--- a/src/data_gradients/dataset_adapters/formatters/base.py
+++ b/src/data_gradients/dataset_adapters/formatters/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 import torch
-from data_gradients.dataset_adapters.config.questions import FixedOptionsQuestion
+from data_gradients.dataset_adapters.config.questions import OpenEndedQuestion
 
 
 class BatchFormatter(ABC):
@@ -25,10 +25,20 @@ class BatchFormatter(ABC):
     def get_n_image_channels(self, images: torch.Tensor) -> int:
         """Get the number of image channels in the batch. If not set yet, it will be asked to the user."""
         if self._n_image_channels is None:
-            question = FixedOptionsQuestion(
-                question="Which dimension corresponds the image channel? ",
-                options={dim: dim for dim in images.shape},
+            question = OpenEndedQuestion(
+                question="Please describe your image channels?",
             )
-            hint = f"Image shape: {images.shape}"
-            self._n_image_channels = self.data_config.get_n_image_channels(question=question, hint=hint)
+            hint = (
+                f"Image shape: {images.shape}\n\n"
+                "Options:\n"
+                "  - `RGB`\n"
+                "  - `BGR`\n"
+                "  - `L` (Grayscale)\n"
+                "  - `LAB`\n"
+                "Note: If your image has extra channels, you please add a `O` for each of them.\n\n"
+                "E.g. If you have image has 4 (Red, Green, Blue, Depth), you should enter `RGBO` (in the right order!)"
+            )
+
+            image_channels = self.data_config.get_image_channels(question=question, hint=hint)
+            self._n_image_channels = len(image_channels)
         return self._n_image_channels

--- a/src/data_gradients/dataset_adapters/output_mapper/tensor_extractor.py
+++ b/src/data_gradients/dataset_adapters/output_mapper/tensor_extractor.py
@@ -104,7 +104,7 @@ class NestedDataLookup:
 
 
 def extract_keys_from_path(object_path: str) -> List[Union[str, int]]:
-    """Parse the path to an object into a list of indexes.
+    """Parse the path to an object into a list of idx_to_visualize.
 
     >> extract_keys_from_path("field1.field12[0]") # Which originally represents {"field1": {"field12": [<object>, ...], ...}, ...}
     ["field1", "field12", 0]  # Can be used like this: data["field1"]["field12"][0] = <object>

--- a/src/data_gradients/datasets/base_dataset.py
+++ b/src/data_gradients/datasets/base_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 from torch.utils.data.dataset import Dataset
 
 from data_gradients.datasets.FolderProcessor import ImageLabelFilesIterator, DEFAULT_IMG_EXTENSIONS
-from data_gradients.datasets.utils import load_image, ImageChannelFormat
+from data_gradients.datasets.utils import load_image, str
 
 
 class BaseImageLabelDirectoryDataset(Dataset, ABC):
@@ -44,7 +44,7 @@ class BaseImageLabelDirectoryDataset(Dataset, ABC):
 
     def load_image(self, path: str) -> np.ndarray:
         """Load an image from the given path into RGB format."""
-        return load_image(path, ImageChannelFormat.RGB)
+        return load_image(path, str.RGB)
 
     @abstractmethod
     def load_labels(self, path: str) -> np.ndarray:

--- a/src/data_gradients/datasets/base_dataset.py
+++ b/src/data_gradients/datasets/base_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 from torch.utils.data.dataset import Dataset
 
 from data_gradients.datasets.FolderProcessor import ImageLabelFilesIterator, DEFAULT_IMG_EXTENSIONS
-from data_gradients.datasets.utils import load_image, str
+from data_gradients.datasets.utils import load_image_rgb
 
 
 class BaseImageLabelDirectoryDataset(Dataset, ABC):
@@ -44,7 +44,7 @@ class BaseImageLabelDirectoryDataset(Dataset, ABC):
 
     def load_image(self, path: str) -> np.ndarray:
         """Load an image from the given path into RGB format."""
-        return load_image(path, str.RGB)
+        return load_image_rgb(path)
 
     @abstractmethod
     def load_labels(self, path: str) -> np.ndarray:

--- a/src/data_gradients/datasets/segmentation/voc_format_segmentation_dataset.py
+++ b/src/data_gradients/datasets/segmentation/voc_format_segmentation_dataset.py
@@ -3,7 +3,7 @@ from typing import Sequence, Optional
 
 from data_gradients.datasets.base_dataset import BaseImageLabelDirectoryDataset
 from data_gradients.datasets.FolderProcessor import DEFAULT_IMG_EXTENSIONS
-from data_gradients.datasets.utils import load_image, str
+from data_gradients.datasets.utils import load_image_rgb
 
 
 class VOCFormatSegmentationDataset(BaseImageLabelDirectoryDataset):
@@ -121,7 +121,7 @@ class VOCFormatSegmentationDataset(BaseImageLabelDirectoryDataset):
         :param path:    Path to the label image file.
         :return:        Mask of the label image, in (H, W) format, where Mij represents the class_id.
         """
-        mask = load_image(path, str.RGB)
+        mask = load_image_rgb(path)
         classes = np.zeros_like(mask[:, :, 0], dtype=int)
 
         for class_idx, color in enumerate(self.color_map):

--- a/src/data_gradients/datasets/segmentation/voc_format_segmentation_dataset.py
+++ b/src/data_gradients/datasets/segmentation/voc_format_segmentation_dataset.py
@@ -3,7 +3,7 @@ from typing import Sequence, Optional
 
 from data_gradients.datasets.base_dataset import BaseImageLabelDirectoryDataset
 from data_gradients.datasets.FolderProcessor import DEFAULT_IMG_EXTENSIONS
-from data_gradients.datasets.utils import load_image, ImageChannelFormat
+from data_gradients.datasets.utils import load_image, str
 
 
 class VOCFormatSegmentationDataset(BaseImageLabelDirectoryDataset):
@@ -121,7 +121,7 @@ class VOCFormatSegmentationDataset(BaseImageLabelDirectoryDataset):
         :param path:    Path to the label image file.
         :return:        Mask of the label image, in (H, W) format, where Mij represents the class_id.
         """
-        mask = load_image(path, ImageChannelFormat.RGB)
+        mask = load_image(path, str.RGB)
         classes = np.zeros_like(mask[:, :, 0], dtype=int)
 
         for class_idx, color in enumerate(self.color_map):

--- a/src/data_gradients/datasets/utils.py
+++ b/src/data_gradients/datasets/utils.py
@@ -1,18 +1,18 @@
 import cv2
 import numpy as np
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import str
 
 
-def load_image(path: str, channel_format: ImageChannelFormat = ImageChannelFormat.BGR) -> np.ndarray:
+def load_image(path: str, channel_format: str = str.BGR) -> np.ndarray:
     """Load an image from a path in a specified format."""
-    if channel_format == ImageChannelFormat.BGR:
+    if channel_format == str.BGR:
         return cv2.imread(path, cv2.IMREAD_COLOR)
-    elif channel_format == ImageChannelFormat.RGB:
+    elif channel_format == str.RGB:
         img = cv2.imread(path, cv2.IMREAD_COLOR)
         return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    elif channel_format == ImageChannelFormat.GRAYSCALE:
+    elif channel_format == str.GRAYSCALE:
         return cv2.imread(path, cv2.IMREAD_GRAYSCALE)
-    elif channel_format == ImageChannelFormat.UNCHANGED:
+    elif channel_format == str.UNCHANGED:
         return cv2.imread(path, cv2.IMREAD_UNCHANGED)
     else:
         raise NotImplementedError(f"Channel format {channel_format} is not supported for loading image")

--- a/src/data_gradients/datasets/utils.py
+++ b/src/data_gradients/datasets/utils.py
@@ -1,18 +1,10 @@
 import cv2
 import numpy as np
-from data_gradients.utils.data_classes.data_samples import str
 
 
-def load_image(path: str, channel_format: str = str.BGR) -> np.ndarray:
-    """Load an image from a path in a specified format."""
-    if channel_format == str.BGR:
-        return cv2.imread(path, cv2.IMREAD_COLOR)
-    elif channel_format == str.RGB:
-        img = cv2.imread(path, cv2.IMREAD_COLOR)
-        return cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    elif channel_format == str.GRAYSCALE:
-        return cv2.imread(path, cv2.IMREAD_GRAYSCALE)
-    elif channel_format == str.UNCHANGED:
-        return cv2.imread(path, cv2.IMREAD_UNCHANGED)
-    else:
-        raise NotImplementedError(f"Channel format {channel_format} is not supported for loading image")
+def load_image_rgb(path: str) -> np.ndarray:
+    """Load an image from a path in a RGB.
+
+    :return: The image as a numpy array. (H, W, 3)
+    """
+    return cv2.imread(path, cv2.IMREAD_COLOR)

--- a/src/data_gradients/feature_extractors/common/image_average_brightness.py
+++ b/src/data_gradients/feature_extractors/common/image_average_brightness.py
@@ -17,7 +17,7 @@ class ImagesAverageBrightness(AbstractFeatureExtractor):
         self.data = []
 
     def update(self, sample: ImageSample):
-        self.data.append({"split": sample.split, "brightness": sample.image_as_lab[0].mean()})
+        self.data.append({"split": sample.split, "brightness": sample.image_mean_intensity})
 
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)

--- a/src/data_gradients/feature_extractors/common/image_average_brightness.py
+++ b/src/data_gradients/feature_extractors/common/image_average_brightness.py
@@ -17,7 +17,7 @@ class ImagesAverageBrightness(AbstractFeatureExtractor):
         self.data = []
 
     def update(self, sample: ImageSample):
-        self.data.append({"split": sample.split, "brightness": sample.image_luminescence})
+        self.data.append({"split": sample.split, "brightness": sample.image_as_lab[0].mean()})
 
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)

--- a/src/data_gradients/feature_extractors/common/image_average_brightness.py
+++ b/src/data_gradients/feature_extractors/common/image_average_brightness.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.abstract_feature_extractor import AbstractFeatureExtractor
-from data_gradients.utils.data_classes.data_samples import ImageSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import ImageSample, str
 from data_gradients.visualize.plot_options import KDEPlotOptions
 from data_gradients.visualize.plot_options import BarPlotOptions
 from data_gradients.feature_extractors.abstract_feature_extractor import Feature
@@ -28,13 +28,13 @@ class ImagesAverageBrightness(AbstractFeatureExtractor):
                     f"Inconstancy in the image format. The image format of the sample {sample.sample_id} is not the same as the previous sample."
                 )
 
-        if self.image_format == ImageChannelFormat.RGB:
+        if self.image_format == str.RGB:
             brightness = np.mean(cv2.cvtColor(sample.image, cv2.COLOR_RGB2LAB)[0])
-        elif self.image_format == ImageChannelFormat.BGR:
+        elif self.image_format == str.BGR:
             brightness = np.mean(cv2.cvtColor(sample.image, cv2.COLOR_BGR2LAB)[0])
-        elif self.image_format == ImageChannelFormat.GRAYSCALE:
+        elif self.image_format == str.GRAYSCALE:
             brightness = np.mean(sample.image)
-        elif self.image_format == ImageChannelFormat.UNKNOWN:
+        elif self.image_format == str.UNKNOWN:
             brightness = np.mean(sample.image)
         else:
             raise ValueError(f"Unknown image format {sample.image_format}")

--- a/src/data_gradients/feature_extractors/common/image_average_brightness.py
+++ b/src/data_gradients/feature_extractors/common/image_average_brightness.py
@@ -1,10 +1,8 @@
-import cv2
-import numpy as np
 import pandas as pd
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.abstract_feature_extractor import AbstractFeatureExtractor
-from data_gradients.utils.data_classes.data_samples import ImageSample, str
+from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.visualize.plot_options import KDEPlotOptions
 from data_gradients.visualize.plot_options import BarPlotOptions
 from data_gradients.feature_extractors.abstract_feature_extractor import Feature
@@ -15,31 +13,11 @@ class ImagesAverageBrightness(AbstractFeatureExtractor):
     """Extracts the distribution of the image 'brightness'."""
 
     def __init__(self):
-        self.image_format = None
+        self.image_channels = None
         self.data = []
 
     def update(self, sample: ImageSample):
-
-        if self.image_format is None:
-            self.image_format = sample.image_format
-        else:
-            if self.image_format != sample.image_format:
-                raise RuntimeError(
-                    f"Inconstancy in the image format. The image format of the sample {sample.sample_id} is not the same as the previous sample."
-                )
-
-        if self.image_format == str.RGB:
-            brightness = np.mean(cv2.cvtColor(sample.image, cv2.COLOR_RGB2LAB)[0])
-        elif self.image_format == str.BGR:
-            brightness = np.mean(cv2.cvtColor(sample.image, cv2.COLOR_BGR2LAB)[0])
-        elif self.image_format == str.GRAYSCALE:
-            brightness = np.mean(sample.image)
-        elif self.image_format == str.UNKNOWN:
-            brightness = np.mean(sample.image)
-        else:
-            raise ValueError(f"Unknown image format {sample.image_format}")
-
-        self.data.append({"split": sample.split, "brightness": brightness})
+        self.data.append({"split": sample.split, "brightness": sample.image_luminescence})
 
     def aggregate(self) -> Feature:
         df = pd.DataFrame(self.data)

--- a/src/data_gradients/feature_extractors/common/image_color_distribution.py
+++ b/src/data_gradients/feature_extractors/common/image_color_distribution.py
@@ -1,10 +1,9 @@
-import cv2
 import pandas as pd
 import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.abstract_feature_extractor import AbstractFeatureExtractor
-from data_gradients.utils.data_classes.data_samples import ImageSample, str
+from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.visualize.plot_options import KDEPlotOptions
 from data_gradients.feature_extractors.abstract_feature_extractor import Feature
 
@@ -14,7 +13,7 @@ class ImageColorDistribution(AbstractFeatureExtractor):
     """Extracts the distribution of the image 'brightness'."""
 
     def __init__(self):
-        self.image_format = None
+        self.image_channels = None
         self.colors = ("Red", "Green", "Blue")
         self.palette = {"Red": "red", "Green": "green", "Blue": "blue", "Grayscale": "gray"}
         self.pixel_frequency_per_channel_per_split = {}
@@ -23,27 +22,7 @@ class ImageColorDistribution(AbstractFeatureExtractor):
 
     def update(self, sample: ImageSample):
 
-        if self.image_format is None:
-            self.image_format = sample.image_format
-        else:
-            if self.image_format != sample.image_format:
-                raise RuntimeError(
-                    f"Inconstancy in the image format. The image format of the sample {sample.sample_id} is not the same as the previous sample."
-                )
-
-        if self.image_format == str.RGB:
-            image = sample.image
-        elif self.image_format == str.BGR:
-            image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif self.image_format == str.GRAYSCALE:
-            image = sample.image[:, :, np.newaxis]
-            self.colors = ("Grayscale",)
-        elif self.image_format == str.UNKNOWN:
-            image = sample.image
-        else:
-            raise ValueError(f"Unknown image format {sample.image_format}")
-
-        sample.image = sample.image.astype(np.uint8)
+        image = sample.image_as_rgb
         pixel_frequency_per_channel = self.pixel_frequency_per_channel_per_split.get(sample.split)
 
         # We need this more complex logic because we cannot directly accumulate the images (this would take too much memory)

--- a/src/data_gradients/feature_extractors/common/image_color_distribution.py
+++ b/src/data_gradients/feature_extractors/common/image_color_distribution.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.abstract_feature_extractor import AbstractFeatureExtractor
-from data_gradients.utils.data_classes.data_samples import ImageSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import ImageSample, str
 from data_gradients.visualize.plot_options import KDEPlotOptions
 from data_gradients.feature_extractors.abstract_feature_extractor import Feature
 
@@ -31,14 +31,14 @@ class ImageColorDistribution(AbstractFeatureExtractor):
                     f"Inconstancy in the image format. The image format of the sample {sample.sample_id} is not the same as the previous sample."
                 )
 
-        if self.image_format == ImageChannelFormat.RGB:
+        if self.image_format == str.RGB:
             image = sample.image
-        elif self.image_format == ImageChannelFormat.BGR:
+        elif self.image_format == str.BGR:
             image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif self.image_format == ImageChannelFormat.GRAYSCALE:
+        elif self.image_format == str.GRAYSCALE:
             image = sample.image[:, :, np.newaxis]
             self.colors = ("Grayscale",)
-        elif self.image_format == ImageChannelFormat.UNKNOWN:
+        elif self.image_format == str.UNKNOWN:
             image = sample.image
         else:
             raise ValueError(f"Unknown image format {sample.image_format}")

--- a/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
@@ -23,6 +23,9 @@ class DetectionSampleVisualization(AbstractSampleVisualization):
         :param sample: Input image sample
         :return: The preprocessed image tensor.
         """
+        if sample.image_as_rgb is None:
+            raise RuntimeError(f"`{self.__class__.__name__}` not compatible with Image format `{sample.image_channels.__class__.__name__}`")
+
         result = draw_bboxes(
             image=sample.image_as_rgb,
             bboxes_xyxy=sample.bboxes_xyxy,

--- a/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
@@ -1,9 +1,8 @@
-import cv2
 import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.common.sample_visualization import AbstractSampleVisualization
-from data_gradients.utils.data_classes.data_samples import DetectionSample, str
+from data_gradients.utils.data_classes.data_samples import DetectionSample
 from data_gradients.visualize.detection.detection import draw_bboxes
 
 
@@ -24,17 +23,10 @@ class DetectionSampleVisualization(AbstractSampleVisualization):
         :param sample: Input image sample
         :return: The preprocessed image tensor.
         """
-
-        if sample.image_format == str.RGB:
-            image = sample.image
-        elif sample.image_format == str.BGR:
-            image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif sample.image_format == str.GRAYSCALE:
-            image = cv2.cvtColor(sample.image, cv2.COLOR_GRAY2RGB)
-        elif sample.image_format == str.UNKNOWN:
-            image = sample.image
-        else:
-            raise ValueError(f"Unknown image format {sample.image_format}")
-
-        result = draw_bboxes(image=image, bboxes_xyxy=sample.bboxes_xyxy, bboxes_ids=sample.class_ids, class_names=sample.class_names)
+        result = draw_bboxes(
+            image=sample.image_as_rgb,
+            bboxes_xyxy=sample.bboxes_xyxy,
+            bboxes_ids=sample.class_ids,
+            class_names=sample.class_names,
+        )
         return result.astype(np.uint8)

--- a/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/object_detection/sample_visualization.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.common.sample_visualization import AbstractSampleVisualization
-from data_gradients.utils.data_classes.data_samples import DetectionSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import DetectionSample, str
 from data_gradients.visualize.detection.detection import draw_bboxes
 
 
@@ -25,13 +25,13 @@ class DetectionSampleVisualization(AbstractSampleVisualization):
         :return: The preprocessed image tensor.
         """
 
-        if sample.image_format == ImageChannelFormat.RGB:
+        if sample.image_format == str.RGB:
             image = sample.image
-        elif sample.image_format == ImageChannelFormat.BGR:
+        elif sample.image_format == str.BGR:
             image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif sample.image_format == ImageChannelFormat.GRAYSCALE:
+        elif sample.image_format == str.GRAYSCALE:
             image = cv2.cvtColor(sample.image, cv2.COLOR_GRAY2RGB)
-        elif sample.image_format == ImageChannelFormat.UNKNOWN:
+        elif sample.image_format == str.UNKNOWN:
             image = sample.image
         else:
             raise ValueError(f"Unknown image format {sample.image_format}")

--- a/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.common.sample_visualization import AbstractSampleVisualization
-from data_gradients.utils.data_classes.data_samples import SegmentationSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import SegmentationSample, str
 
 
 @register_feature_extractor()
@@ -27,13 +27,13 @@ class SegmentationSampleVisualization(AbstractSampleVisualization):
         :return: The preprocessed image tensor.
         """
 
-        if sample.image_format == ImageChannelFormat.RGB:
+        if sample.image_format == str.RGB:
             image = sample.image
-        elif sample.image_format == ImageChannelFormat.BGR:
+        elif sample.image_format == str.BGR:
             image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif sample.image_format == ImageChannelFormat.GRAYSCALE:
+        elif sample.image_format == str.GRAYSCALE:
             image = cv2.cvtColor(sample.image, cv2.COLOR_GRAY2RGB)
-        elif sample.image_format == ImageChannelFormat.UNKNOWN:
+        elif sample.image_format == str.UNKNOWN:
             image = sample.image
         else:
             raise ValueError(f"Unknown image format {sample.image_format}")

--- a/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
@@ -25,6 +25,10 @@ class SegmentationSampleVisualization(AbstractSampleVisualization):
         :param sample: Input image sample
         :return: The preprocessed image tensor.
         """
+
+        if sample.image_as_rgb is None:
+            raise RuntimeError(f"`{self.__class__.__name__}` not compatible with Image format `{sample.image_channels.__class__.__name__}`")
+
         image = sample.image_as_rgb
 
         # Onehot to categorical labels

--- a/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
+++ b/src/data_gradients/feature_extractors/segmentation/sample_visualization.py
@@ -1,9 +1,8 @@
-import cv2
 import numpy as np
 
 from data_gradients.common.registry.registry import register_feature_extractor
 from data_gradients.feature_extractors.common.sample_visualization import AbstractSampleVisualization
-from data_gradients.utils.data_classes.data_samples import SegmentationSample, str
+from data_gradients.utils.data_classes.data_samples import SegmentationSample
 
 
 @register_feature_extractor()
@@ -26,17 +25,7 @@ class SegmentationSampleVisualization(AbstractSampleVisualization):
         :param sample: Input image sample
         :return: The preprocessed image tensor.
         """
-
-        if sample.image_format == str.RGB:
-            image = sample.image
-        elif sample.image_format == str.BGR:
-            image = cv2.cvtColor(sample.image, cv2.COLOR_BGR2RGB)
-        elif sample.image_format == str.GRAYSCALE:
-            image = cv2.cvtColor(sample.image, cv2.COLOR_GRAY2RGB)
-        elif sample.image_format == str.UNKNOWN:
-            image = sample.image
-        else:
-            raise ValueError(f"Unknown image format {sample.image_format}")
+        image = sample.image_as_rgb
 
         # Onehot to categorical labels
         categorical_labels = np.argmax(sample.mask, axis=0)

--- a/src/data_gradients/managers/classification_manager.py
+++ b/src/data_gradients/managers/classification_manager.py
@@ -9,7 +9,6 @@ from data_gradients.config.utils import get_grouped_feature_extractors
 from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.classification_sample_preprocessor import ClassificationSamplePreprocessor
-from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config.data_config import ClassificationDataConfig
 
 
@@ -34,10 +33,9 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         images_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         labels_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         is_batch: Optional[bool] = None,
-        n_image_channels: Optional[int] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: str = str.RGB,
+        image_channels: Optional[str] = None,
     ):
         """
         Constructor of detection manager which controls the analyzer
@@ -56,7 +54,6 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         :param use_cache:               Whether to use cache or not for the configuration of the data.
         :param images_extractor:        Function extracting the image(s) out of the data output.
         :param labels_extractor:        Function extracting the label(s) out of the data output.
-        :param n_image_channels:        Number of channels for each image in the dataset
         :param remove_plots_after_report:  Delete the plots from the report directory after the report is generated. By default, True
         """
 
@@ -67,8 +64,7 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = ClassificationDataConfig(
             cache_path=cache_path,
-            n_image_channels=n_image_channels,
-            image_format=image_format,
+            image_channels=image_channels,
             n_classes=n_classes,
             class_names=class_names,
             images_extractor=images_extractor,

--- a/src/data_gradients/managers/classification_manager.py
+++ b/src/data_gradients/managers/classification_manager.py
@@ -35,7 +35,6 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         is_batch: Optional[bool] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_channels: Optional[str] = None,
     ):
         """
         Constructor of detection manager which controls the analyzer
@@ -64,7 +63,6 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = ClassificationDataConfig(
             cache_path=cache_path,
-            image_channels=image_channels,
             n_classes=n_classes,
             class_names=class_names,
             images_extractor=images_extractor,

--- a/src/data_gradients/managers/classification_manager.py
+++ b/src/data_gradients/managers/classification_manager.py
@@ -9,7 +9,7 @@ from data_gradients.config.utils import get_grouped_feature_extractors
 from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.classification_sample_preprocessor import ClassificationSamplePreprocessor
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config.data_config import ClassificationDataConfig
 
 
@@ -34,10 +34,10 @@ class ClassificationAnalysisManager(AnalysisManagerAbstract):
         images_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         labels_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         is_batch: Optional[bool] = None,
-        n_image_channels: int = 3,
+        n_image_channels: Optional[int] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: ImageChannelFormat = ImageChannelFormat.RGB,
+        image_format: str = str.RGB,
     ):
         """
         Constructor of detection manager which controls the analyzer

--- a/src/data_gradients/managers/detection_manager.py
+++ b/src/data_gradients/managers/detection_manager.py
@@ -11,7 +11,7 @@ from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.detection_sample_preprocessor import DetectionSamplePreprocessor
 from data_gradients.datasets import COCOFormatDetectionDataset, VOCDetectionDataset, COCODetectionDataset
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config import DetectionDataConfig
 
 
@@ -39,10 +39,10 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         is_batch: Optional[bool] = None,
         is_label_first: Optional[bool] = None,
         bbox_format: Optional[str] = None,
-        n_image_channels: int = 3,
+        n_image_channels: Optional[int] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: ImageChannelFormat = ImageChannelFormat.RGB,
+        image_format: str = str.RGB,
     ):
         """
         Constructor of detection manager which controls the analyzer

--- a/src/data_gradients/managers/detection_manager.py
+++ b/src/data_gradients/managers/detection_manager.py
@@ -11,7 +11,6 @@ from data_gradients.managers.abstract_manager import AnalysisManagerAbstract
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.detection_sample_preprocessor import DetectionSamplePreprocessor
 from data_gradients.datasets import COCOFormatDetectionDataset, VOCDetectionDataset, COCODetectionDataset
-from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config import DetectionDataConfig
 
 
@@ -39,10 +38,9 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         is_batch: Optional[bool] = None,
         is_label_first: Optional[bool] = None,
         bbox_format: Optional[str] = None,
-        n_image_channels: Optional[int] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: str = str.RGB,
+        image_channels: Optional[str] = None,
     ):
         """
         Constructor of detection manager which controls the analyzer
@@ -65,7 +63,6 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         :param is_label_first:          Whether the labels are in the first dimension or not.
                                             > (class_id, x, y, w, h) for instance, as opposed to (x, y, w, h, class_id)
         :param bbox_format:             Format of the bounding boxes. 'xyxy', 'xywh' or 'cxcywh'
-        :param n_image_channels:        Number of channels for each image in the dataset
         :param remove_plots_after_report:  Delete the plots from the report directory after the report is generated. By default, True
         """
         if feature_extractors is not None and config_path is not None:
@@ -76,8 +73,7 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = DetectionDataConfig(
             cache_path=cache_path,
-            n_image_channels=n_image_channels,
-            image_format=image_format,
+            image_channels=image_channels,
             n_classes=n_classes,
             class_names=class_names,
             class_names_to_use=class_names_to_use,

--- a/src/data_gradients/managers/detection_manager.py
+++ b/src/data_gradients/managers/detection_manager.py
@@ -40,7 +40,6 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         bbox_format: Optional[str] = None,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_channels: Optional[str] = None,
     ):
         """
         Constructor of detection manager which controls the analyzer
@@ -73,7 +72,6 @@ class DetectionAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = DetectionDataConfig(
             cache_path=cache_path,
-            image_channels=image_channels,
             n_classes=n_classes,
             class_names=class_names,
             class_names_to_use=class_names_to_use,

--- a/src/data_gradients/managers/segmentation_manager.py
+++ b/src/data_gradients/managers/segmentation_manager.py
@@ -40,7 +40,6 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         threshold_soft_labels: float = 0.5,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_channels: Optional[str] = None,
     ):
         """
         Constructor of semantic-segmentation manager which controls the analyzer
@@ -71,7 +70,6 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = SegmentationDataConfig(
             class_names=class_names,
-            image_channels=image_channels,
             n_classes=n_classes,
             cache_path=cache_path,
             class_names_to_use=class_names_to_use,

--- a/src/data_gradients/managers/segmentation_manager.py
+++ b/src/data_gradients/managers/segmentation_manager.py
@@ -11,7 +11,7 @@ from data_gradients.dataset_adapters.config.typing_utils import SupportedDataTyp
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.segmentation_sample_preprocessor import SegmentationSampleProcessor
 from data_gradients.datasets import COCOSegmentationDataset, COCOFormatSegmentationDataset, VOCSegmentationDataset
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config.data_config import SegmentationDataConfig
 
 
@@ -38,11 +38,11 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         images_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         labels_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         is_batch: Optional[bool] = None,
-        num_image_channels: int = 3,
+        num_image_channels: Optional[int] = None,
         threshold_soft_labels: float = 0.5,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: ImageChannelFormat = ImageChannelFormat.RGB,
+        image_format: str = str.RGB,
     ):
         """
         Constructor of semantic-segmentation manager which controls the analyzer

--- a/src/data_gradients/managers/segmentation_manager.py
+++ b/src/data_gradients/managers/segmentation_manager.py
@@ -11,7 +11,6 @@ from data_gradients.dataset_adapters.config.typing_utils import SupportedDataTyp
 from data_gradients.utils.summary_writer import SummaryWriter
 from data_gradients.sample_preprocessor.segmentation_sample_preprocessor import SegmentationSampleProcessor
 from data_gradients.datasets import COCOSegmentationDataset, COCOFormatSegmentationDataset, VOCSegmentationDataset
-from data_gradients.utils.data_classes.data_samples import str
 from data_gradients.dataset_adapters.config.data_config import SegmentationDataConfig
 
 
@@ -38,11 +37,10 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         images_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         labels_extractor: Optional[Callable[[SupportedDataType], torch.Tensor]] = None,
         is_batch: Optional[bool] = None,
-        num_image_channels: Optional[int] = None,
         threshold_soft_labels: float = 0.5,
         batches_early_stop: Optional[int] = None,
         remove_plots_after_report: Optional[bool] = True,
-        image_format: str = str.RGB,
+        image_channels: Optional[str] = None,
     ):
         """
         Constructor of semantic-segmentation manager which controls the analyzer
@@ -63,7 +61,6 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         :param use_cache:               Whether to use cache or not for the configuration of the data.
         :param images_extractor:        Function extracting the image(s) out of the data output.
         :param labels_extractor:        Function extracting the label(s) out of the data output.
-        :param num_image_channels:      Number of channels for each image in the dataset
         :param threshold_soft_labels:   Threshold for converting soft labels to binary labels
         :param remove_plots_after_report:  Delete the plots from the report directory after the report is generated. By default, True
         """
@@ -74,8 +71,7 @@ class SegmentationAnalysisManager(AnalysisManagerAbstract):
         cache_path = os.path.join(get_default_cache_dir(), f"{summary_writer.run_name}.json") if use_cache else None
         data_config = SegmentationDataConfig(
             class_names=class_names,
-            n_image_channels=num_image_channels,
-            image_format=image_format,
+            image_channels=image_channels,
             n_classes=n_classes,
             cache_path=cache_path,
             class_names_to_use=class_names_to_use,

--- a/src/data_gradients/sample_preprocessor/classification_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/classification_sample_preprocessor.py
@@ -29,7 +29,7 @@ class ClassificationSamplePreprocessor(AbstractSamplePreprocessor):
                     class_id=class_id,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_channels=self.data_config.get_image_channels(),
+                    image_channels=self.data_config.get_image_channels(image=image),
                     sample_id=str(time.time()),
                 )
                 yield sample

--- a/src/data_gradients/sample_preprocessor/classification_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/classification_sample_preprocessor.py
@@ -29,7 +29,7 @@ class ClassificationSamplePreprocessor(AbstractSamplePreprocessor):
                     class_id=class_id,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_format=self.data_config.get_image_format(),
+                    image_channels=self.data_config.get_image_channels(),
                     sample_id=str(time.time()),
                 )
                 yield sample

--- a/src/data_gradients/sample_preprocessor/detection_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/detection_sample_preprocessor.py
@@ -31,6 +31,6 @@ class DetectionSamplePreprocessor(AbstractSamplePreprocessor):
                     bboxes_xyxy=bboxes_xyxy,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_format=self.data_config.get_image_format(),
+                    image_channels=self.data_config.get_image_channels(),
                     sample_id=str(time.time()),
                 )

--- a/src/data_gradients/sample_preprocessor/detection_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/detection_sample_preprocessor.py
@@ -31,6 +31,6 @@ class DetectionSamplePreprocessor(AbstractSamplePreprocessor):
                     bboxes_xyxy=bboxes_xyxy,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_channels=self.data_config.get_image_channels(),
+                    image_channels=self.data_config.get_image_channels(image=image),
                     sample_id=str(time.time()),
                 )

--- a/src/data_gradients/sample_preprocessor/segmentation_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/segmentation_sample_preprocessor.py
@@ -32,6 +32,6 @@ class SegmentationSampleProcessor(AbstractSamplePreprocessor):
                     contours=contours,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_format=self.data_config.get_image_format(),
+                    image_channels=self.data_config.get_image_channels(),
                     sample_id=str(time.time()),
                 )

--- a/src/data_gradients/sample_preprocessor/segmentation_sample_preprocessor.py
+++ b/src/data_gradients/sample_preprocessor/segmentation_sample_preprocessor.py
@@ -32,6 +32,6 @@ class SegmentationSampleProcessor(AbstractSamplePreprocessor):
                     contours=contours,
                     class_names=self.data_config.get_class_names(),
                     split=split,
-                    image_channels=self.data_config.get_image_channels(),
+                    image_channels=self.data_config.get_image_channels(image=image),
                     sample_id=str(time.time()),
                 )

--- a/src/data_gradients/utils/data_classes/data_samples.py
+++ b/src/data_gradients/utils/data_classes/data_samples.py
@@ -1,18 +1,10 @@
 import dataclasses
-from enum import Enum
 from typing import List
 
 import numpy as np
 
 from data_gradients.utils.data_classes.contour import Contour
-
-
-class str(Enum):
-    RGB = "RGB"
-    BGR = "BGR"
-    GRAYSCALE = "GRAYSCALE"
-    UNKNOWN = "UNKNOWN"
-    UNCHANGED = "UNCHANGED"
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 @dataclasses.dataclass
@@ -28,10 +20,22 @@ class ImageSample:
     sample_id: str
     split: str
     image: np.ndarray
-    image_format: str
+    image_channels: ImageChannels  # TODO: rename
 
     def __repr__(self):
-        return f"ImageSample(sample_id={self.sample_id}, image={self.image.shape}, format={self.image_format})"
+        return f"ImageSample(sample_id={self.sample_id}, image={self.image.shape}, format={self.image_channels})"
+
+    @property
+    def image_as_rgb(self) -> np.ndarray:
+        return self.image_channels.convert_image_to_rgb(image=self.image)
+
+    @property
+    def image_channels_to_visualize(self) -> np.ndarray:
+        return self.image_channels.get_channels_to_visualize(image=self.image)
+
+    @property
+    def image_luminescence(self) -> np.ndarray:
+        return self.image_channels.compute_image_luminescence(image=self.image)
 
 
 @dataclasses.dataclass

--- a/src/data_gradients/utils/data_classes/data_samples.py
+++ b/src/data_gradients/utils/data_classes/data_samples.py
@@ -34,8 +34,8 @@ class ImageSample:
         return self.image_channels.get_channels_to_visualize(image=self.image)
 
     @property
-    def image_as_lab(self) -> np.ndarray:
-        return self.image_channels.convert_image_to_lab(image=self.image)
+    def image_mean_intensity(self) -> float:
+        return self.image_channels.compute_mean_image_intensity(image=self.image)
 
 
 @dataclasses.dataclass

--- a/src/data_gradients/utils/data_classes/data_samples.py
+++ b/src/data_gradients/utils/data_classes/data_samples.py
@@ -34,8 +34,8 @@ class ImageSample:
         return self.image_channels.get_channels_to_visualize(image=self.image)
 
     @property
-    def image_luminescence(self) -> np.ndarray:
-        return self.image_channels.compute_image_luminescence(image=self.image)
+    def image_as_lab(self) -> np.ndarray:
+        return self.image_channels.convert_image_to_lab(image=self.image)
 
 
 @dataclasses.dataclass

--- a/src/data_gradients/utils/data_classes/data_samples.py
+++ b/src/data_gradients/utils/data_classes/data_samples.py
@@ -7,7 +7,7 @@ import numpy as np
 from data_gradients.utils.data_classes.contour import Contour
 
 
-class ImageChannelFormat(Enum):
+class str(Enum):
     RGB = "RGB"
     BGR = "BGR"
     GRAYSCALE = "GRAYSCALE"
@@ -28,7 +28,7 @@ class ImageSample:
     sample_id: str
     split: str
     image: np.ndarray
-    image_format: ImageChannelFormat
+    image_format: str
 
     def __repr__(self):
         return f"ImageSample(sample_id={self.sample_id}, image={self.image.shape}, format={self.image_format})"

--- a/src/data_gradients/utils/data_classes/image_channels.py
+++ b/src/data_gradients/utils/data_classes/image_channels.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 import cv2
 import numpy as np
@@ -11,13 +12,15 @@ class ImageChannels(ABC):
     >> ImageChannels.from_str("RGBO") # This represents the format of an image with (R, G, B, ?) channels, where `?` can be any other channel (Depth, ...)
     """
 
-    def __init__(self, channels_str: str):
+    def __init__(self, channels_str: str, idx_to_visualize: slice, channel_names: List[str]):
         """
         :param channels_str: The string representation of the channels. `RGB`, `LAB`, `RGBO`, ... Each channel is represented by a letter.
         """
         if not self.validate_channels(channels_str=channels_str):
             raise ValueError(f"Invalid `channels_str={channels_str}` for `{self.__class__.__name__}`")
         self.channels_str = channels_str
+        self.idx_to_visualize = idx_to_visualize
+        self.channel_names = channel_names
 
     def __repr__(self):
         return self.channels_str
@@ -30,19 +33,12 @@ class ImageChannels(ABC):
     def validate_channels(channels_str: str) -> bool:
         raise NotImplementedError()
 
-    @property
-    def _format_str(self) -> str:
-        """Represent the format of an image (`RGB`, `BGR`, `G`, `LAB`). This is independently to any extra channels.
-        If an image is represented by the channels (Heat, Red, Green, Blue, Depth), then the format should be simply `RGB`."""
-        raise NotImplementedError()
-
     def get_channels_to_visualize(self, image: np.ndarray) -> np.ndarray:
         """Get the channels that represent an image
         :param image:   The image to convert of shape [H, W, C] with C the number of channels of the image.
         :return:        The converted image in shape [H, W, n] with n the number of channels to visualize.
         """
-        format_idx = self.channels_str.index(self._format_str)
-        return image[:, :, format_idx : format_idx + len(self._format_str)]
+        return image[:, :, self.idx_to_visualize]
 
     @abstractmethod
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
@@ -55,12 +51,12 @@ class ImageChannels(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
-        """Convert an input image to LAB.
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        """Convert the mean intensity of an image.
 
         :param image:   The image to convert of shape [H, W, C].
                         This image should include the channel as defined by `self.channels_str`.
-        :return:        The converted image in shape [H, W, 3] with channels LAB
+        :return:        float, representing the mean intensity of the input image.
         """
         raise NotImplementedError()
 
@@ -102,9 +98,25 @@ class ImageChannels(ABC):
 
 
 class RGBChannels(ImageChannels):
-    @property
-    def _format_str(self) -> str:
-        return "RGB"
+    def __init__(self, channels_str: str):
+        format_idx = channels_str.index("RGB")
+
+        channel_names = []
+        for i, channel_str in enumerate(channels_str):
+            if channel_str == "R":
+                channel_names.append("Red")
+            elif channel_str == "G":
+                channel_names.append("Green")
+            elif channel_str == "B":
+                channel_names.append("Blue")
+            else:
+                channel_names.append(f"Channel_{i}")
+
+        super().__init__(
+            channels_str=channels_str,
+            idx_to_visualize=slice(format_idx, format_idx + 3),
+            channel_names=channel_names,
+        )
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
@@ -114,14 +126,30 @@ class RGBChannels(ImageChannels):
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return self.get_channels_to_visualize(image)
 
-    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
-        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)[0].mean()
 
 
 class BGRChannels(ImageChannels):
-    @property
-    def _format_str(self) -> str:
-        return "BGR"
+    def __init__(self, channels_str: str):
+        format_idx = channels_str.index("BGR")
+
+        channel_names = []
+        for i, channel_str in enumerate(channels_str):
+            if channel_str == "R":
+                channel_names.append("Red")
+            elif channel_str == "G":
+                channel_names.append("Green")
+            elif channel_str == "B":
+                channel_names.append("Blue")
+            else:
+                channel_names.append(f"Channel_{i}")
+
+        super().__init__(
+            channels_str=channels_str,
+            idx_to_visualize=slice(format_idx, format_idx + 3),
+            channel_names=channel_names,
+        )
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
@@ -131,14 +159,26 @@ class BGRChannels(ImageChannels):
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2RGB)
 
-    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
-        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2LAB)
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2LAB)[0].mean()
 
 
 class GrayscaleChannels(ImageChannels):
-    @property
-    def _format_str(self) -> str:
-        return "G"
+    def __init__(self, channels_str: str):
+        format_idx = channels_str.index("G")
+
+        channel_names = []
+        for i, channel_str in enumerate(channels_str):
+            if channel_str == "G":
+                channel_names.append("Grayscale")
+            else:
+                channel_names.append(f"Channel_{i}")
+
+        super().__init__(
+            channels_str=channels_str,
+            idx_to_visualize=slice(format_idx, format_idx + 3),
+            channel_names=channel_names,
+        )
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
@@ -148,15 +188,30 @@ class GrayscaleChannels(ImageChannels):
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)
 
-    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
-        image = cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)  # No way to convert to LAB directly
-        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        return image.mean()
 
 
 class LABChannels(ImageChannels):
-    @property
-    def _format_str(self) -> str:
-        return "LAB"
+    def __init__(self, channels_str: str):
+        format_idx = channels_str.index("LAB")
+
+        channel_names = []
+        for i, channel_str in enumerate(channels_str):
+            if channel_str == "L":
+                channel_names.append("Luminance")
+            elif channel_str == "A":
+                channel_names.append("A")
+            elif channel_str == "B":
+                channel_names.append("B")
+            else:
+                channel_names.append(f"Channel_{i}")
+
+        super().__init__(
+            channels_str=channels_str,
+            idx_to_visualize=slice(format_idx, format_idx + 3),
+            channel_names=channel_names,
+        )
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
@@ -166,8 +221,27 @@ class LABChannels(ImageChannels):
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_LAB2RGB)
 
-    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
-        return image
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        return image[0].mean()
+
+
+class OtherChannels(ImageChannels):
+    def __init__(self, channels_str: str):
+        super().__init__(
+            channels_str=channels_str,
+            idx_to_visualize=slice(0, 1),
+            channel_names=[f"Channel_{i}" for i in range(len(channels_str))],
+        )
+
+    @staticmethod
+    def validate_channels(channels_str: str) -> bool:
+        return channels_str.count("O") == len(channels_str)
+
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        return None
+
+    def compute_mean_image_intensity(self, image: np.ndarray) -> float:
+        return image.mean()
 
 
 def image_channel_instance_factory(channels_str: str) -> ImageChannels:
@@ -199,7 +273,7 @@ def image_channel_instance_factory(channels_str: str) -> ImageChannels:
     # Check which channel representation fits the given string.
     potential_channel_classes = [
         ChannelClass(channels_str)
-        for ChannelClass in [RGBChannels, BGRChannels, GrayscaleChannels, LABChannels]
+        for ChannelClass in [RGBChannels, BGRChannels, GrayscaleChannels, LABChannels, OtherChannels]
         if ChannelClass.validate_channels(channels_str)
     ]
 

--- a/src/data_gradients/utils/data_classes/image_channels.py
+++ b/src/data_gradients/utils/data_classes/image_channels.py
@@ -5,7 +5,18 @@ import numpy as np
 
 
 class ImageChannels(ABC):
+    """Represent the channels of an image.
+
+    >> ImageChannels.from_str("LAB") # This represents the format of LAB color space.
+    >> ImageChannels.from_str("RGBO") # This represents the format of an image with (R, G, B, ?) channels, where `?` can be any other channel (Depth, ...)
+    """
+
     def __init__(self, channels_str: str):
+        """
+        :param channels_str: The string representation of the channels. `RGB`, `LAB`, `RGBO`, ... Each channel is represented by a letter.
+        """
+        if not self.validate_channels(channels_str=channels_str):
+            raise ValueError(f"Invalid `channels_str={channels_str}` for `{self.__class__.__name__}`")
         self.channels_str = channels_str
 
     def __repr__(self):
@@ -14,49 +25,91 @@ class ImageChannels(ABC):
     def __len__(self) -> int:
         return len(self.channels_str)
 
-    @property
-    def format_idx(self):
-        return self.channels_str.index(self.format_str)
-
-    def get_channels_to_visualize(self, image: np.ndarray) -> np.ndarray:
-        return image[:, :, self.format_idx : self.format_idx + len(self)]
-
     @staticmethod
     @abstractmethod
     def validate_channels(channels_str: str) -> bool:
         raise NotImplementedError()
 
     @property
-    def format_str(self) -> str:
+    def _format_str(self) -> str:
+        """Represent the format of an image (`RGB`, `BGR`, `G`, `LAB`). This is independently to any extra channels.
+        If an image is represented by the channels (Heat, Red, Green, Blue, Depth), then the format should be simply `RGB`."""
         raise NotImplementedError()
+
+    def get_channels_to_visualize(self, image: np.ndarray) -> np.ndarray:
+        """Get the channels that represent an image
+        :param image:   The image to convert of shape [H, W, C] with C the number of channels of the image.
+        :return:        The converted image in shape [H, W, n] with n the number of channels to visualize.
+        """
+        format_idx = self.channels_str.index(self._format_str)
+        return image[:, :, format_idx : format_idx + len(self._format_str)]
 
     @abstractmethod
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        """Convert an input image to RGB.
+
+        :param image:   The image to convert of shape [H, W, C].
+                        This image should include the channel as defined by `self.channels_str`.
+        :return:        The converted image in shape [H, W, 3] with channels RGB
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        """Convert an input image to LAB.
+
+        :param image:   The image to convert of shape [H, W, C].
+                        This image should include the channel as defined by `self.channels_str`.
+        :return:        The converted image in shape [H, W, 3] with channels LAB
+        """
         raise NotImplementedError()
 
-    def compute_image_luminescence(self, image: np.ndarray) -> np.ndarray:
-        return self.convert_image_to_lab(image)[0].mean()
-
     def to_str(self) -> str:
+        """String representation of the image channels.
+
+        This should be reverse `from_str`:
+            >> assert ImageChannels.from_str(channel_str).to_str() == channel_str
+        """
         return self.channels_str
 
     @classmethod
     def from_str(cls, channels_str: str) -> "ImageChannels":
+        """
+        Create an ImageChannels instance based on the channel representation string.
+
+        The function determines the appropriate subclass of ImageChannels (e.g., RGBChannels, BGRChannels) based on the
+        given string representation of the channels. It also considers additional channels (represented by 'O') present
+        in the image.
+
+        :param channels_str:    String representing the channels in the image. Valid channel representations include:
+                                    - 'RGB': Red, Green, Blue channels
+                                    - 'BGR': Blue, Green, Red channels
+                                    - 'G': Grayscale channel
+                                    - 'LAB': Luminance, A and B color channels
+                                    - 'O': Any additional channel (e.g., Depth)
+        :return:                ImageChannels instance corresponding to the channel representation string.
+
+        Examples:
+        >> image_channel_instance_factory('RGB')
+        RGB
+        >> image_channel_instance_factory('RGBO')
+        RGBO (with the last channel being an additional channel, e.g., Depth)
+
+        Notes:
+        - The order of channels in the string representation is significant and should match the order of channels in the image.
+        """
         return image_channel_instance_factory(channels_str)
 
 
 class RGBChannels(ImageChannels):
     @property
-    def format_str(self) -> str:
+    def _format_str(self) -> str:
         return "RGB"
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
-        return channels_str.count("RGB") == 1
+        """A valid RGB channel representation string should have `RGB` once and `O` the rest of the channels.`"""
+        return channels_str.count("RGB") == 1 and channels_str.count("O") == len(channels_str) - 3
 
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return self.get_channels_to_visualize(image)
@@ -67,12 +120,13 @@ class RGBChannels(ImageChannels):
 
 class BGRChannels(ImageChannels):
     @property
-    def format_str(self) -> str:
+    def _format_str(self) -> str:
         return "BGR"
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
-        return channels_str.count("BGR") == 1
+        """A valid BGR channel representation string should have `BGR` once and `O` the rest of the channels.`"""
+        return channels_str.count("BGR") == 1 and channels_str.count("O") == len(channels_str) - 3
 
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2RGB)
@@ -83,12 +137,13 @@ class BGRChannels(ImageChannels):
 
 class GrayscaleChannels(ImageChannels):
     @property
-    def format_str(self) -> str:
-        return "L"
+    def _format_str(self) -> str:
+        return "G"
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
-        return channels_str.count("L") == 1 and "LAB" not in channels_str
+        """A valid Grayscale channel representation string should have `G` once and `O` the rest of the channels.`"""
+        return channels_str.count("G") == 1 and channels_str.count("O") == len(channels_str) - 1
 
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)
@@ -97,19 +152,16 @@ class GrayscaleChannels(ImageChannels):
         image = cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)  # No way to convert to LAB directly
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)
 
-    def compute_image_luminescence(self, image: np.ndarray) -> np.ndarray:
-        # We override the default implementation, because this is more computationally efficient.
-        return self.get_channels_to_visualize(image).mean()
-
 
 class LABChannels(ImageChannels):
     @property
-    def format_str(self) -> str:
+    def _format_str(self) -> str:
         return "LAB"
 
     @staticmethod
     def validate_channels(channels_str: str) -> bool:
-        return channels_str.count("LAB") == 1
+        """A valid LAB channel representation string should have `LAB` once and `O` the rest of the channels.`"""
+        return channels_str.count("LAB") == 1 and channels_str.count("O") == len(channels_str) - 3
 
     def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
         return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_LAB2RGB)
@@ -119,14 +171,43 @@ class LABChannels(ImageChannels):
 
 
 def image_channel_instance_factory(channels_str: str) -> ImageChannels:
-    available_channel_classes = [RGBChannels, BGRChannels, GrayscaleChannels, LABChannels]
+    """
+    Create an ImageChannels instance based on the channel representation string.
 
-    potential_channel_classes = [ChannelClass(channels_str) for ChannelClass in available_channel_classes if ChannelClass.validate_channels(channels_str)]
+    The function determines the appropriate subclass of ImageChannels (e.g., RGBChannels, BGRChannels) based on the
+    given string representation of the channels. It also considers additional channels (represented by 'O') present
+    in the image.
 
+    :param channels_str:    String representing the channels in the image. Valid channel representations include:
+                                - 'RGB': Red, Green, Blue channels
+                                - 'BGR': Blue, Green, Red channels
+                                - 'G': Grayscale channel
+                                - 'LAB': Luminance, A and B color channels
+                                - 'O': Any additional channel (e.g., Depth)
+    :return:                ImageChannels instance corresponding to the channel representation string.
+
+    Examples:
+    >> image_channel_instance_factory('RGB')
+    RGB
+    >> image_channel_instance_factory('RGBO')
+    RGBO (with the last channel being an additional channel, e.g., Depth)
+
+    Notes:
+    - The order of channels in the string representation is significant and should match the order of channels in the image.
+    """
+
+    # Check which channel representation fits the given string.
+    potential_channel_classes = [
+        ChannelClass(channels_str)
+        for ChannelClass in [RGBChannels, BGRChannels, GrayscaleChannels, LABChannels]
+        if ChannelClass.validate_channels(channels_str)
+    ]
+
+    # Only accept case without ambiguous channel representation.
     if len(potential_channel_classes) == 1:
         return potential_channel_classes[0]
     if len(potential_channel_classes) > 1:
-        formats_str = ", ".join([channel_class.format_str for channel_class in potential_channel_classes])
+        formats_str = ", ".join([channel_class._format_str for channel_class in potential_channel_classes])
         raise ValueError(
             f"Image channel representation `channels_str={channels_str}` is ambiguous between the following formats: {formats_str}\n"
             f"Please make sure to provide a channel representation that is not ambiguous."

--- a/src/data_gradients/utils/data_classes/image_channels.py
+++ b/src/data_gradients/utils/data_classes/image_channels.py
@@ -1,0 +1,135 @@
+from abc import ABC, abstractmethod
+
+import cv2
+import numpy as np
+
+
+class ImageChannels(ABC):
+    def __init__(self, channels_str: str):
+        self.channels_str = channels_str
+
+    def __repr__(self):
+        return self.channels_str
+
+    def __len__(self) -> int:
+        return len(self.channels_str)
+
+    @property
+    def format_idx(self):
+        return self.channels_str.index(self.format_str)
+
+    def get_channels_to_visualize(self, image: np.ndarray) -> np.ndarray:
+        return image[:, :, self.format_idx : self.format_idx + len(self)]
+
+    @staticmethod
+    @abstractmethod
+    def validate_channels(channels_str: str) -> bool:
+        raise NotImplementedError()
+
+    @property
+    def format_str(self) -> str:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        raise NotImplementedError()
+
+    def compute_image_luminescence(self, image: np.ndarray) -> np.ndarray:
+        return self.convert_image_to_lab(image)[0].mean()
+
+    def to_str(self) -> str:
+        return self.channels_str
+
+    @classmethod
+    def from_str(cls, channels_str: str) -> "ImageChannels":
+        return image_channel_instance_factory(channels_str)
+
+
+class RGBChannels(ImageChannels):
+    @property
+    def format_str(self) -> str:
+        return "RGB"
+
+    @staticmethod
+    def validate_channels(channels_str: str) -> bool:
+        return channels_str.count("RGB") == 1
+
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        return self.get_channels_to_visualize(image)
+
+    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)
+
+
+class BGRChannels(ImageChannels):
+    @property
+    def format_str(self) -> str:
+        return "BGR"
+
+    @staticmethod
+    def validate_channels(channels_str: str) -> bool:
+        return channels_str.count("BGR") == 1
+
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2RGB)
+
+    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_BGR2LAB)
+
+
+class GrayscaleChannels(ImageChannels):
+    @property
+    def format_str(self) -> str:
+        return "L"
+
+    @staticmethod
+    def validate_channels(channels_str: str) -> bool:
+        return channels_str.count("L") == 1 and "LAB" not in channels_str
+
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)
+
+    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        image = cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_GRAY2RGB)  # No way to convert to LAB directly
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_RGB2LAB)
+
+    def compute_image_luminescence(self, image: np.ndarray) -> np.ndarray:
+        # We override the default implementation, because this is more computationally efficient.
+        return self.get_channels_to_visualize(image).mean()
+
+
+class LABChannels(ImageChannels):
+    @property
+    def format_str(self) -> str:
+        return "LAB"
+
+    @staticmethod
+    def validate_channels(channels_str: str) -> bool:
+        return channels_str.count("LAB") == 1
+
+    def convert_image_to_rgb(self, image: np.ndarray) -> np.ndarray:
+        return cv2.cvtColor(self.get_channels_to_visualize(image), cv2.COLOR_LAB2RGB)
+
+    def convert_image_to_lab(self, image: np.ndarray) -> np.ndarray:
+        return image
+
+
+def image_channel_instance_factory(channels_str: str) -> ImageChannels:
+    available_channel_classes = [RGBChannels, BGRChannels, GrayscaleChannels, LABChannels]
+
+    potential_channel_classes = [ChannelClass(channels_str) for ChannelClass in available_channel_classes if ChannelClass.validate_channels(channels_str)]
+
+    if len(potential_channel_classes) == 1:
+        return potential_channel_classes[0]
+    if len(potential_channel_classes) > 1:
+        formats_str = ", ".join([channel_class.format_str for channel_class in potential_channel_classes])
+        raise ValueError(
+            f"Image channel representation `channels_str={channels_str}` is ambiguous between the following formats: {formats_str}\n"
+            f"Please make sure to provide a channel representation that is not ambiguous."
+        )
+    else:
+        raise ValueError(f"Unsupported channel format for string: {channels_str}")

--- a/tests/unit_tests/average_brightness_test.py
+++ b/tests/unit_tests/average_brightness_test.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from data_gradients.feature_extractors import ImagesAverageBrightness
 from data_gradients.utils.data_classes import ImageSample
-from data_gradients.utils.data_classes.data_samples import str
 
 
 class AverageBrightnessTest(unittest.TestCase):
@@ -14,13 +13,13 @@ class AverageBrightnessTest(unittest.TestCase):
         self.split = "train"
 
     def test_black_image(self):
-        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=str.RGB)
+        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=str.RGB)
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
 
     def test_white_image(self):
-        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=str.RGB)
+        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=str.RGB)
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
@@ -28,7 +27,7 @@ class AverageBrightnessTest(unittest.TestCase):
     def test_noise_image(self):
         image = np.ones((100, 100, 1), dtype=np.uint8)
         image[:50, :100] = 0
-        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_format=str.GRAYSCALE)
+        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_channels=str.GRAYSCALE)
 
         target_value = np.mean(image)
         self.assertAlmostEqual(target_value, 0.5)

--- a/tests/unit_tests/average_brightness_test.py
+++ b/tests/unit_tests/average_brightness_test.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from data_gradients.feature_extractors import ImagesAverageBrightness
 from data_gradients.utils.data_classes import ImageSample
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class AverageBrightnessTest(unittest.TestCase):
@@ -13,13 +14,13 @@ class AverageBrightnessTest(unittest.TestCase):
         self.split = "train"
 
     def test_black_image(self):
-        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=str.RGB)
+        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=ImageChannels.from_str("RGB"))
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
 
     def test_white_image(self):
-        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=str.RGB)
+        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_channels=ImageChannels.from_str("RGB"))
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
@@ -27,7 +28,7 @@ class AverageBrightnessTest(unittest.TestCase):
     def test_noise_image(self):
         image = np.ones((100, 100, 1), dtype=np.uint8)
         image[:50, :100] = 0
-        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_channels=str.GRAYSCALE)
+        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_channels=ImageChannels.from_str("G"))
 
         target_value = np.mean(image)
         self.assertAlmostEqual(target_value, 0.5)

--- a/tests/unit_tests/average_brightness_test.py
+++ b/tests/unit_tests/average_brightness_test.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from data_gradients.feature_extractors import ImagesAverageBrightness
 from data_gradients.utils.data_classes import ImageSample
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import str
 
 
 class AverageBrightnessTest(unittest.TestCase):
@@ -14,13 +14,13 @@ class AverageBrightnessTest(unittest.TestCase):
         self.split = "train"
 
     def test_black_image(self):
-        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=ImageChannelFormat.RGB)
+        sample = ImageSample(image=np.zeros((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=str.RGB)
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
 
     def test_white_image(self):
-        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=ImageChannelFormat.RGB)
+        sample = ImageSample(image=np.ones((100, 100, 3), dtype=np.uint8), split=self.split, sample_id="Random", image_format=str.RGB)
         feature_extractor = ImagesAverageBrightness()
         feature_extractor.update(sample)
         feature_extractor.aggregate()
@@ -28,7 +28,7 @@ class AverageBrightnessTest(unittest.TestCase):
     def test_noise_image(self):
         image = np.ones((100, 100, 1), dtype=np.uint8)
         image[:50, :100] = 0
-        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_format=ImageChannelFormat.GRAYSCALE)
+        sample = ImageSample(image=image, split=self.split, sample_id="Random", image_format=str.GRAYSCALE)
 
         target_value = np.mean(image)
         self.assertAlmostEqual(target_value, 0.5)

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
@@ -7,6 +7,7 @@ import numpy as np
 from data_gradients.feature_extractors import ClassificationClassDistributionVsArea
 from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class ClassificationClassDistributionTest(unittest.TestCase):
@@ -21,7 +22,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=0,
                     class_names=class_names,
                 )
@@ -34,7 +35,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=1,
                     class_names=class_names,
                 )
@@ -47,7 +48,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=2,
                     class_names=class_names,
                 )
@@ -60,7 +61,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=3,
                     class_names=class_names,
                 )
@@ -73,7 +74,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
@@ -5,7 +5,7 @@ import uuid
 import numpy as np
 
 from data_gradients.feature_extractors import ClassificationClassDistributionVsArea
-from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
+from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -21,7 +21,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )
@@ -34,7 +34,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=1,
                     class_names=class_names,
                 )
@@ -47,7 +47,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=2,
                     class_names=class_names,
                 )
@@ -60,7 +60,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=3,
                     class_names=class_names,
                 )
@@ -73,7 +73,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area.py
@@ -5,7 +5,7 @@ import uuid
 import numpy as np
 
 from data_gradients.feature_extractors import ClassificationClassDistributionVsArea
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat, ClassificationSample
+from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -21,7 +21,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )
@@ -34,7 +34,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=1,
                     class_names=class_names,
                 )
@@ -47,7 +47,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=2,
                     class_names=class_names,
                 )
@@ -60,7 +60,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=3,
                     class_names=class_names,
                 )
@@ -73,7 +73,7 @@ class ClassificationClassDistributionTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
@@ -7,6 +7,7 @@ import numpy as np
 from data_gradients.feature_extractors.classification.class_distribution_vs_area_scatter import ClassificationClassDistributionVsAreaPlot
 from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
@@ -21,7 +22,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=0,
                     class_names=class_names,
                 )
@@ -34,7 +35,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=1,
                     class_names=class_names,
                 )
@@ -47,7 +48,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=2,
                     class_names=class_names,
                 )
@@ -60,7 +61,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=3,
                     class_names=class_names,
                 )
@@ -73,7 +74,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_channels=str.RGB,
+                    image_channels=ImageChannels.from_str("RGB"),
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
@@ -4,10 +4,8 @@ import uuid
 
 import numpy as np
 
-from data_gradients.feature_extractors import ClassificationClassDistributionVsArea
-from data_gradients.feature_extractors.classification.class_distribution_vs_area_scatter import \
-    ClassificationClassDistributionVsAreaPlot
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat, ClassificationSample
+from data_gradients.feature_extractors.classification.class_distribution_vs_area_scatter import ClassificationClassDistributionVsAreaPlot
+from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -23,7 +21,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )
@@ -36,7 +34,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=1,
                     class_names=class_names,
                 )
@@ -49,7 +47,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=2,
                     class_names=class_names,
                 )
@@ -62,7 +60,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=3,
                     class_names=class_names,
                 )
@@ -75,7 +73,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=ImageChannelFormat.RGB,
+                    image_format=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_distribution_vs_area_plot.py
@@ -5,7 +5,7 @@ import uuid
 import numpy as np
 
 from data_gradients.feature_extractors.classification.class_distribution_vs_area_scatter import ClassificationClassDistributionVsAreaPlot
-from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
+from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -21,7 +21,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )
@@ -34,7 +34,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=1,
                     class_names=class_names,
                 )
@@ -47,7 +47,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="train",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=2,
                     class_names=class_names,
                 )
@@ -60,7 +60,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=3,
                     class_names=class_names,
                 )
@@ -73,7 +73,7 @@ class ClassificationClassDistributionVsAreaPlotTest(unittest.TestCase):
                     sample_id=str(uuid.uuid4()),
                     split="valid",
                     image=dummy_image,
-                    image_format=str.RGB,
+                    image_channels=str.RGB,
                     class_id=0,
                     class_names=class_names,
                 )

--- a/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from data_gradients.feature_extractors.classification.class_frequency import ClassificationClassFrequency
-from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
+from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -18,7 +18,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_1",
                 split="train",
                 image=dummy_image,
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 class_id=0,
                 class_names=class_names,
             )
@@ -29,7 +29,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_2",
                 split="train",
                 image=dummy_image,
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 class_id=1,
                 class_names=class_names,
             )
@@ -39,7 +39,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_3",
                 split="train",
                 image=dummy_image,
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 class_id=2,
                 class_names=class_names,
             )
@@ -50,7 +50,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_4",
                 split="valid",
                 image=dummy_image,
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 class_id=3,
                 class_names=class_names,
             )
@@ -60,7 +60,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_5",
                 split="valid",
                 image=dummy_image,
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 class_id=0,
                 class_names=class_names,
             )

--- a/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from data_gradients.feature_extractors.classification.class_frequency import ClassificationClassFrequency
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat, ClassificationSample
+from data_gradients.utils.data_classes.data_samples import str, ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -18,7 +18,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_1",
                 split="train",
                 image=dummy_image,
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 class_id=0,
                 class_names=class_names,
             )
@@ -29,7 +29,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_2",
                 split="train",
                 image=dummy_image,
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 class_id=1,
                 class_names=class_names,
             )
@@ -39,7 +39,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_3",
                 split="train",
                 image=dummy_image,
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 class_id=2,
                 class_names=class_names,
             )
@@ -50,7 +50,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_4",
                 split="valid",
                 image=dummy_image,
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 class_id=3,
                 class_names=class_names,
             )
@@ -60,7 +60,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_5",
                 split="valid",
                 image=dummy_image,
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 class_id=0,
                 class_names=class_names,
             )

--- a/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
+++ b/tests/unit_tests/feature_extractors/classification/test_class_frequency.py
@@ -5,6 +5,7 @@ import numpy as np
 from data_gradients.feature_extractors.classification.class_frequency import ClassificationClassFrequency
 from data_gradients.utils.data_classes.data_samples import ClassificationSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class ClassificationClassFrequencyTest(unittest.TestCase):
@@ -18,7 +19,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_1",
                 split="train",
                 image=dummy_image,
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 class_id=0,
                 class_names=class_names,
             )
@@ -29,7 +30,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_2",
                 split="train",
                 image=dummy_image,
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 class_id=1,
                 class_names=class_names,
             )
@@ -39,7 +40,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_3",
                 split="train",
                 image=dummy_image,
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 class_id=2,
                 class_names=class_names,
             )
@@ -50,7 +51,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_4",
                 split="valid",
                 image=dummy_image,
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 class_id=3,
                 class_names=class_names,
             )
@@ -60,7 +61,7 @@ class ClassificationClassFrequencyTest(unittest.TestCase):
                 sample_id="sample_5",
                 split="valid",
                 image=dummy_image,
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 class_id=0,
                 class_names=class_names,
             )

--- a/tests/unit_tests/feature_extractors/common/test_image_brightness.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_brightness.py
@@ -5,6 +5,7 @@ from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.feature_extractors.common.image_average_brightness import ImagesAverageBrightness
 from data_gradients.feature_extractors.common.image_color_distribution import ImageColorDistribution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class ImageBrightnessTest(unittest.TestCase):
@@ -17,7 +18,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=train_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -29,7 +30,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=train_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -40,7 +41,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -51,7 +52,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -63,7 +64,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -75,7 +76,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -87,7 +88,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_5",
             split="valid",
             image=valid_image,
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)

--- a/tests/unit_tests/feature_extractors/common/test_image_brightness.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_brightness.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import ImageSample, str
+from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.feature_extractors.common.image_average_brightness import ImagesAverageBrightness
 from data_gradients.feature_extractors.common.image_color_distribution import ImageColorDistribution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
@@ -17,7 +17,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=train_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -29,7 +29,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=train_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -40,7 +40,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -51,7 +51,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -63,7 +63,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -75,7 +75,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -87,7 +87,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_5",
             split="valid",
             image=valid_image,
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)

--- a/tests/unit_tests/feature_extractors/common/test_image_brightness.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_brightness.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import ImageSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import ImageSample, str
 from data_gradients.feature_extractors.common.image_average_brightness import ImagesAverageBrightness
 from data_gradients.feature_extractors.common.image_color_distribution import ImageColorDistribution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
@@ -17,7 +17,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=train_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -29,7 +29,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=train_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -40,7 +40,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -51,7 +51,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=train_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(train_sample)
         self.color_distribution.update(train_sample)
@@ -63,7 +63,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -75,7 +75,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=valid_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)
@@ -87,7 +87,7 @@ class ImageBrightnessTest(unittest.TestCase):
             sample_id="sample_5",
             split="valid",
             image=valid_image,
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.average_brightness.update(valid_sample)
         self.color_distribution.update(valid_sample)

--- a/tests/unit_tests/feature_extractors/common/test_image_resolution.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_resolution.py
@@ -4,6 +4,7 @@ import numpy as np
 from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.feature_extractors.common.image_resolution import ImagesResolution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class ImageResolutionTest(unittest.TestCase):
@@ -14,7 +15,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_0",
             split="train",
             image=np.zeros((50, 100, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(train_sample)
 
@@ -22,7 +23,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((150, 250, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(train_sample)
 
@@ -30,7 +31,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=np.zeros((150, 200, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(train_sample)
 
@@ -38,7 +39,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((150, 300, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(train_sample)
 
@@ -46,7 +47,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((200, 200, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(train_sample)
 
@@ -54,7 +55,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((100, 100, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(valid_sample)
 
@@ -62,7 +63,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((150, 150, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(valid_sample)
 
@@ -70,7 +71,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((200, 250, 3), dtype=np.uint8),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
         )
         self.extractor.update(valid_sample)
 

--- a/tests/unit_tests/feature_extractors/common/test_image_resolution.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_resolution.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import ImageSample, str
+from data_gradients.utils.data_classes.data_samples import ImageSample
 from data_gradients.feature_extractors.common.image_resolution import ImagesResolution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
@@ -14,7 +14,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_0",
             split="train",
             image=np.zeros((50, 100, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -22,7 +22,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((150, 250, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -30,7 +30,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=np.zeros((150, 200, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -38,7 +38,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((150, 300, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -46,7 +46,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((200, 200, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -54,7 +54,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((100, 100, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(valid_sample)
 
@@ -62,7 +62,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((150, 150, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(valid_sample)
 
@@ -70,7 +70,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((200, 250, 3), dtype=np.uint8),
-            image_format=str.RGB,
+            image_channels=str.RGB,
         )
         self.extractor.update(valid_sample)
 

--- a/tests/unit_tests/feature_extractors/common/test_image_resolution.py
+++ b/tests/unit_tests/feature_extractors/common/test_image_resolution.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import ImageSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import ImageSample, str
 from data_gradients.feature_extractors.common.image_resolution import ImagesResolution
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
@@ -14,7 +14,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_0",
             split="train",
             image=np.zeros((50, 100, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -22,7 +22,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((150, 250, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -30,7 +30,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_2",
             split="train",
             image=np.zeros((150, 200, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -38,7 +38,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((150, 300, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -46,7 +46,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_3",
             split="train",
             image=np.zeros((200, 200, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(train_sample)
 
@@ -54,7 +54,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((100, 100, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(valid_sample)
 
@@ -62,7 +62,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((150, 150, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(valid_sample)
 
@@ -70,7 +70,7 @@ class ImageResolutionTest(unittest.TestCase):
             sample_id="sample_4",
             split="valid",
             image=np.zeros((200, 250, 3), dtype=np.uint8),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
         )
         self.extractor.update(valid_sample)
 

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
@@ -4,106 +4,60 @@ import numpy as np
 import pandas as pd
 
 from data_gradients.feature_extractors.object_detection.bounding_boxes_area import DetectionBoundingBoxArea
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat, DetectionSample
+from data_gradients.utils.data_classes.data_samples import str, DetectionSample
 
 
 class TestComputeHistogram(unittest.TestCase):
     def test_compute_histogram(self):
-        test_df = pd.DataFrame({
-            'bbox_area_sqrt': [1, 2, 3, 3, 3, 2, 3],
-            'split': ['train', 'train', 'train', 'train', 'val', 'val', 'val'],
-            'class_name': ['A', 'B', 'A', 'A', 'B', 'A', 'C']
-        })
+        test_df = pd.DataFrame(
+            {
+                "bbox_area_sqrt": [1, 2, 3, 3, 3, 2, 3],
+                "split": ["train", "train", "train", "train", "val", "val", "val"],
+                "class_name": ["A", "B", "A", "A", "B", "A", "C"],
+            }
+        )
 
-        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name='sqrt')
+        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name="sqrt")
 
         expected_result = {
-            'train': {
-                'transform': 'sqrt',
-                'bin_width': 1,
-                'max_value': 3,
-                'histograms': {
-                    'A': [0, 1, 0, 2],
-                    'B': [0, 0, 1, 0]
-                }
-            },
-            'val': {
-                'transform': 'sqrt',
-                'bin_width': 1,
-                'max_value': 3,
-                'histograms': {
-                    'A': [0, 0, 1, 0],
-                    'B': [0, 0, 0, 1],
-                    'C': [0, 0, 0, 1]
-                }
-            }
+            "train": {"transform": "sqrt", "bin_width": 1, "max_value": 3, "histograms": {"A": [0, 1, 0, 2], "B": [0, 0, 1, 0]}},
+            "val": {"transform": "sqrt", "bin_width": 1, "max_value": 3, "histograms": {"A": [0, 0, 1, 0], "B": [0, 0, 0, 1], "C": [0, 0, 0, 1]}},
         }
 
         self.assertEqual(result, expected_result)
 
     def test_single_data_point(self):
-        test_df = pd.DataFrame({'bbox_area_sqrt': [1], 'split': ['train'], 'class_name': ['A']})
-        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name='sqrt')
+        test_df = pd.DataFrame({"bbox_area_sqrt": [1], "split": ["train"], "class_name": ["A"]})
+        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name="sqrt")
 
-        expected_result = {
-            'train': {
-                'transform': 'sqrt',
-                'bin_width': 1,
-                'max_value': 1,
-                'histograms': {
-                    'A': [0, 1]
-                }
-            }
-        }
+        expected_result = {"train": {"transform": "sqrt", "bin_width": 1, "max_value": 1, "histograms": {"A": [0, 1]}}}
 
         self.assertEqual(result, expected_result)
 
     def test_minimum_maximum_values(self):
-        test_df = pd.DataFrame({
-            'bbox_area_sqrt': [1, 100],
-            'split': ['val', 'val'],
-            'class_name': ['A', 'A']
-        })
-        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name='sqrt')
+        test_df = pd.DataFrame({"bbox_area_sqrt": [1, 100], "split": ["val", "val"], "class_name": ["A", "A"]})
+        result = DetectionBoundingBoxArea._compute_histogram(test_df, transform_name="sqrt")
 
-        expected_result = {
-            'val': {
-                'transform': 'sqrt',
-                'bin_width': 1,
-                'max_value': 100,
-                'histograms': {
-                    'A': [0] + [1] + [0] * 98 + [1]
-                }
-            }
-        }
+        expected_result = {"val": {"transform": "sqrt", "bin_width": 1, "max_value": 100, "histograms": {"A": [0] + [1] + [0] * 98 + [1]}}}
 
         self.assertEqual(result, expected_result)
 
     def test_histogram_json_output(self):
         train_sample = DetectionSample(
-            sample_id='sample_1',
-            split='train',
+            sample_id="sample_1",
+            split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
-            bboxes_xyxy=np.array(
-                [
-                    [2, 2, 4, 4],
-                    [3, 3, 6, 6],
-                    [1, 1, 5, 5],
-                    [1, 1, 4, 4],
-                    [5, 5, 6, 6],
-                    [7, 7, 9, 9]
-                ]
-            ),
+            image_format=str.RGB,
+            bboxes_xyxy=np.array([[2, 2, 4, 4], [3, 3, 6, 6], [1, 1, 5, 5], [1, 1, 4, 4], [5, 5, 6, 6], [7, 7, 9, 9]]),
             class_ids=np.array([0, 1, 2, 2, 3, 4]),
-            class_names=['A', 'B', 'C', 'D', 'E'],
+            class_names=["A", "B", "C", "D", "E"],
         )
 
         val_sample = DetectionSample(
-            sample_id='sample_2',
-            split='val',
+            sample_id="sample_2",
+            split="val",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [1, 1, 3, 3],
@@ -112,7 +66,7 @@ class TestComputeHistogram(unittest.TestCase):
                 ]
             ),
             class_ids=np.array([0, 1, 1]),
-            class_names=['A', 'B'],
+            class_names=["A", "B"],
         )
 
         extractor = DetectionBoundingBoxArea()
@@ -120,35 +74,21 @@ class TestComputeHistogram(unittest.TestCase):
         extractor.update(val_sample)
         feature = extractor.aggregate()
 
-        histogram_dict_train = feature.json['train']['histogram_per_class']
-        histogram_dict_val = feature.json['val']['histogram_per_class']
+        histogram_dict_train = feature.json["train"]["histogram_per_class"]
+        histogram_dict_val = feature.json["val"]["histogram_per_class"]
 
         expected_result_train = {
-            'transform': 'sqrt',
-            'bin_width': 1,
-            'max_value': 4,
-            'histograms': {
-                'A': [0, 0, 1, 0, 0],
-                'B': [0, 0, 0, 1, 0],
-                'C': [0, 0, 0, 1, 1],
-                'D': [0, 1, 0, 0, 0],
-                'E': [0, 0, 1, 0, 0]
-            }
+            "transform": "sqrt",
+            "bin_width": 1,
+            "max_value": 4,
+            "histograms": {"A": [0, 0, 1, 0, 0], "B": [0, 0, 0, 1, 0], "C": [0, 0, 0, 1, 1], "D": [0, 1, 0, 0, 0], "E": [0, 0, 1, 0, 0]},
         }
 
-        expected_result_val = {
-            'transform': 'sqrt',
-            'bin_width': 1,
-            'max_value': 4,
-            'histograms': {
-                'A': [0, 0, 1, 0, 0],
-                'B': [0, 1, 0, 1, 0]
-            }
-        }
+        expected_result_val = {"transform": "sqrt", "bin_width": 1, "max_value": 4, "histograms": {"A": [0, 0, 1, 0, 0], "B": [0, 1, 0, 1, 0]}}
 
         self.assertEqual(histogram_dict_train, expected_result_train)
         self.assertEqual(histogram_dict_val, expected_result_val)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from data_gradients.feature_extractors.object_detection.bounding_boxes_area import DetectionBoundingBoxArea
 from data_gradients.utils.data_classes.data_samples import DetectionSample
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class TestComputeHistogram(unittest.TestCase):
@@ -47,7 +48,7 @@ class TestComputeHistogram(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             bboxes_xyxy=np.array([[2, 2, 4, 4], [3, 3, 6, 6], [1, 1, 5, 5], [1, 1, 4, 4], [5, 5, 6, 6], [7, 7, 9, 9]]),
             class_ids=np.array([0, 1, 2, 2, 3, 4]),
             class_names=["A", "B", "C", "D", "E"],
@@ -57,7 +58,7 @@ class TestComputeHistogram(unittest.TestCase):
             sample_id="sample_2",
             split="val",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             bboxes_xyxy=np.array(
                 [
                     [1, 1, 3, 3],

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_area.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from data_gradients.feature_extractors.object_detection.bounding_boxes_area import DetectionBoundingBoxArea
-from data_gradients.utils.data_classes.data_samples import str, DetectionSample
+from data_gradients.utils.data_classes.data_samples import DetectionSample
 
 
 class TestComputeHistogram(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestComputeHistogram(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             bboxes_xyxy=np.array([[2, 2, 4, 4], [3, 3, 6, 6], [1, 1, 5, 5], [1, 1, 4, 4], [5, 5, 6, 6], [7, 7, 9, 9]]),
             class_ids=np.array([0, 1, 2, 2, 3, 4]),
             class_names=["A", "B", "C", "D", "E"],
@@ -57,7 +57,7 @@ class TestComputeHistogram(unittest.TestCase):
             sample_id="sample_2",
             split="val",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [1, 1, 3, 3],

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from data_gradients.feature_extractors.object_detection.bounding_boxes_iou import DetectionBoundingBoxIoU
-from data_gradients.utils.data_classes.data_samples import ImageChannelFormat, DetectionSample
+from data_gradients.utils.data_classes.data_samples import str, DetectionSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -22,7 +22,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
                 sample_id=str(sample_index),
                 split="train" if random.random() < 0.8 else "val",
                 image=np.zeros((640, 640, 3)),
-                image_format=ImageChannelFormat.RGB,
+                image_format=str.RGB,
                 bboxes_xyxy=bboxes_xyxy,
                 class_ids=class_ids,
                 class_names=class_names,
@@ -35,7 +35,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [10, 10, 20, 20],
@@ -54,7 +54,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [40, 40, 50, 50],

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
@@ -6,6 +6,7 @@ import numpy as np
 from data_gradients.feature_extractors.object_detection.bounding_boxes_iou import DetectionBoundingBoxIoU
 from data_gradients.utils.data_classes.data_samples import DetectionSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class BoundingBoxesIoUTest(unittest.TestCase):
@@ -22,7 +23,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
                 sample_id=str(sample_index),
                 split="train" if random.random() < 0.8 else "val",
                 image=np.zeros((640, 640, 3)),
-                image_channels=str.RGB,
+                image_channels=ImageChannels.from_str("RGB"),
                 bboxes_xyxy=bboxes_xyxy,
                 class_ids=class_ids,
                 class_names=class_names,
@@ -35,7 +36,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             bboxes_xyxy=np.array(
                 [
                     [10, 10, 20, 20],
@@ -54,7 +55,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             bboxes_xyxy=np.array(
                 [
                     [40, 40, 50, 50],

--- a/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
+++ b/tests/unit_tests/feature_extractors/detection/test_bounding_boxes_iou.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from data_gradients.feature_extractors.object_detection.bounding_boxes_iou import DetectionBoundingBoxIoU
-from data_gradients.utils.data_classes.data_samples import str, DetectionSample
+from data_gradients.utils.data_classes.data_samples import DetectionSample
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
 
 
@@ -22,7 +22,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
                 sample_id=str(sample_index),
                 split="train" if random.random() < 0.8 else "val",
                 image=np.zeros((640, 640, 3)),
-                image_format=str.RGB,
+                image_channels=str.RGB,
                 bboxes_xyxy=bboxes_xyxy,
                 class_ids=class_ids,
                 class_names=class_names,
@@ -35,7 +35,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [10, 10, 20, 20],
@@ -54,7 +54,7 @@ class BoundingBoxesIoUTest(unittest.TestCase):
             sample_id="sample_1",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             bboxes_xyxy=np.array(
                 [
                     [40, 40, 50, 50],

--- a/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
@@ -8,6 +8,7 @@ from data_gradients.feature_extractors.segmentation.bounding_boxes_resolution im
 from data_gradients.feature_extractors.segmentation.classes_frequency import SegmentationClassesCount
 from data_gradients.feature_extractors.segmentation.classes_frequency_per_image import SegmentationClassesPerImageCount
 from data_gradients.visualize.seaborn_renderer import SeabornRenderer
+from data_gradients.utils.data_classes.image_channels import ImageChannels
 
 
 class SegmentationBBoxTest(unittest.TestCase):
@@ -16,7 +17,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [
@@ -102,7 +103,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_2",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_channels=str.RGB,
+            image_channels=ImageChannels.from_str("RGB"),
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [

--- a/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import SegmentationSample, ImageChannelFormat
+from data_gradients.utils.data_classes.data_samples import SegmentationSample, str
 from data_gradients.utils.data_classes.contour import Contour
 from data_gradients.feature_extractors.segmentation.bounding_boxes_area import SegmentationBoundingBoxArea
 from data_gradients.feature_extractors.segmentation.bounding_boxes_resolution import SegmentationBoundingBoxResolution
@@ -16,7 +16,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [
@@ -102,7 +102,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_2",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_format=ImageChannelFormat.RGB,
+            image_format=str.RGB,
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [

--- a/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
+++ b/tests/unit_tests/feature_extractors/segmentation/test_bounding_boxes_area.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 
-from data_gradients.utils.data_classes.data_samples import SegmentationSample, str
+from data_gradients.utils.data_classes.data_samples import SegmentationSample
 from data_gradients.utils.data_classes.contour import Contour
 from data_gradients.feature_extractors.segmentation.bounding_boxes_area import SegmentationBoundingBoxArea
 from data_gradients.feature_extractors.segmentation.bounding_boxes_resolution import SegmentationBoundingBoxResolution
@@ -16,7 +16,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_1",
             split="train",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [
@@ -102,7 +102,7 @@ class SegmentationBBoxTest(unittest.TestCase):
             sample_id="sample_2",
             split="valid",
             image=np.zeros((100, 100, 3)),
-            image_format=str.RGB,
+            image_channels=str.RGB,
             mask=np.zeros((3, 100, 100)),
             contours=[
                 [

--- a/tests/unit_tests/test_image_channels.py
+++ b/tests/unit_tests/test_image_channels.py
@@ -1,0 +1,129 @@
+import unittest
+import numpy as np
+
+# from data_gradients.dataset_adapters.config.data_config import ImageChannels, ImageFormat
+
+from data_gradients.utils.data_classes.image_channels import RGBChannels, BGRChannels, GrayscaleChannels, LABChannels, image_channel_instance_factory
+
+
+class TestImageChannelValidation(unittest.TestCase):
+
+    # RGBChannels tests
+    def test_valid_rgb(self):
+        self.assertTrue(RGBChannels.validate_channels("RGB"))
+        self.assertTrue(RGBChannels.validate_channels("OORGB"))
+
+    def test_invalid_rgb(self):
+        self.assertFalse(RGBChannels.validate_channels("RG"))
+        self.assertFalse(RGBChannels.validate_channels("ORGBOOORGB"))
+
+    # BGRChannels tests
+    def test_valid_bgr(self):
+        self.assertTrue(BGRChannels.validate_channels("BGR"))
+        self.assertTrue(BGRChannels.validate_channels("OBGR"))
+
+    def test_invalid_bgr(self):
+        self.assertFalse(BGRChannels.validate_channels("BRG"))
+        self.assertFalse(BGRChannels.validate_channels("OBGROOBGR"))
+
+    # GrayscaleChannels tests
+    def test_valid_grayscale(self):
+        self.assertTrue(GrayscaleChannels.validate_channels("L"))
+        self.assertTrue(GrayscaleChannels.validate_channels("OL"))
+
+    def test_invalid_grayscale(self):
+        self.assertFalse(GrayscaleChannels.validate_channels("LAB"))
+        self.assertFalse(GrayscaleChannels.validate_channels("LL"))
+        self.assertFalse(GrayscaleChannels.validate_channels("OLOOOLO"))
+
+    # LABChannels tests
+    def test_valid_lab(self):
+        self.assertTrue(LABChannels.validate_channels("LAB"))
+        self.assertTrue(LABChannels.validate_channels("OOLAB"))
+        self.assertTrue(LABChannels.validate_channels("OOLABO"))
+
+    def test_invalid_lab(self):
+        self.assertFalse(LABChannels.validate_channels("ALB"))
+        self.assertFalse(LABChannels.validate_channels("LBA"))
+        self.assertFalse(LABChannels.validate_channels("OLABOOLAB"))
+
+    def test_single_match(self):
+        test_data = [
+            # Standard cases
+            ("RGB", RGBChannels),
+            ("BGR", BGRChannels),
+            ("L", GrayscaleChannels),
+            ("LAB", LABChannels),
+            # Including other irrelevant channels
+            ("OORGB", RGBChannels),
+            ("OBGR", BGRChannels),
+            ("LOOO", GrayscaleChannels),
+            ("OOLABO", LABChannels),
+        ]
+
+        for channels_str, ExpectedClass in test_data:
+            instance = image_channel_instance_factory(channels_str)
+            self.assertIsInstance(instance, ExpectedClass)
+
+    def test_ambiguous_channels(self):
+        # Ambiguous cases
+        ambiguous_channels = ["OORGBBGR", "LOOL", "BGRLO", "LABRGB", "RGBOOOOL"]
+
+        for channels_str in ambiguous_channels:
+            with self.assertRaises(ValueError):
+                image_channel_instance_factory(channels_str)
+
+    def test_unsupported_channels(self):
+        # Unsupported cases
+        unsupported_channels = ["XYZ", "RGO", "LL", "LLOOOLO"]
+
+        for channels_str in unsupported_channels:
+            with self.assertRaises(ValueError) as context:
+                image_channel_instance_factory(channels_str)
+
+            # Check if the error message indicates unsupported format
+            self.assertIn("unsupported", str(context.exception).lower())
+
+    # RGBChannels conversion tests
+    def test_rgb_conversion(self):
+        channels_instance = RGBChannels("OORGBO")
+        image = np.zeros((100, 100, 6), dtype=np.uint8)
+        image[:, :, 2:5] = [255, 0, 0]  # Set RGB to pure Red
+
+        converted_image = channels_instance.convert_image_to_rgb(image)
+        self.assertTrue(np.all(converted_image == [255, 0, 0]))
+
+    # BGRChannels conversion tests
+    def test_bgr_conversion(self):
+        channels_instance = BGRChannels("OOBGRO")
+        image = np.zeros((100, 100, 5), dtype=np.uint8)
+        image[:, :, 2:5] = [0, 0, 255]  # Set BGR to pure Red in BGR
+
+        converted_image = channels_instance.convert_image_to_rgb(image)
+        self.assertTrue(np.all(converted_image == [255, 0, 0]))
+
+    # GrayscaleChannels conversion tests
+    def test_grayscale_conversion(self):
+        channels_instance = GrayscaleChannels("OOLOOO")
+        image = np.zeros((100, 100, 6), dtype=np.uint8)
+        image[:, :, 2] = 128  # Grayscale value
+
+        converted_image = channels_instance.convert_image_to_rgb(image)
+        self.assertTrue(np.all(converted_image == [128, 128, 128]))
+
+    # LABChannels conversion tests
+    def test_lab_conversion(self):
+        channels_instance = LABChannels("OOLABO")
+        image = np.zeros((100, 100, 6), dtype=np.uint8)
+
+        image[:, :, 2:5] = [136, 208, 195]  # Some LAB value (approximating [255, 0, 0])
+        converted_image = channels_instance.convert_image_to_rgb(image)
+
+        # LAB -> RGB and RGB -> LAB is not super stable, so we work with +- 5
+        self.assertTrue(np.all(converted_image[:, :, 0] >= 250))  # R ~ 255
+        self.assertTrue(np.all(converted_image[:, :, 1] <= 5))  # G ~ 0
+        self.assertTrue(np.all(converted_image[:, :, 2] <= 5))  # B ~ 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_image_channels.py
+++ b/tests/unit_tests/test_image_channels.py
@@ -28,13 +28,13 @@ class TestImageChannelValidation(unittest.TestCase):
 
     # GrayscaleChannels tests
     def test_valid_grayscale(self):
-        self.assertTrue(GrayscaleChannels.validate_channels("L"))
-        self.assertTrue(GrayscaleChannels.validate_channels("OL"))
+        self.assertTrue(GrayscaleChannels.validate_channels("G"))
+        self.assertTrue(GrayscaleChannels.validate_channels("OG"))
 
     def test_invalid_grayscale(self):
         self.assertFalse(GrayscaleChannels.validate_channels("LAB"))
-        self.assertFalse(GrayscaleChannels.validate_channels("LL"))
-        self.assertFalse(GrayscaleChannels.validate_channels("OLOOOLO"))
+        self.assertFalse(GrayscaleChannels.validate_channels("GG"))
+        self.assertFalse(GrayscaleChannels.validate_channels("OGOOOGO"))
 
     # LABChannels tests
     def test_valid_lab(self):
@@ -52,12 +52,12 @@ class TestImageChannelValidation(unittest.TestCase):
             # Standard cases
             ("RGB", RGBChannels),
             ("BGR", BGRChannels),
-            ("L", GrayscaleChannels),
+            ("G", GrayscaleChannels),
             ("LAB", LABChannels),
             # Including other irrelevant channels
             ("OORGB", RGBChannels),
             ("OBGR", BGRChannels),
-            ("LOOO", GrayscaleChannels),
+            ("GOOO", GrayscaleChannels),
             ("OOLABO", LABChannels),
         ]
 
@@ -67,7 +67,7 @@ class TestImageChannelValidation(unittest.TestCase):
 
     def test_ambiguous_channels(self):
         # Ambiguous cases
-        ambiguous_channels = ["OORGBBGR", "LOOL", "BGRLO", "LABRGB", "RGBOOOOL"]
+        ambiguous_channels = ["OORGBBGR", "GOOG", "BGRLO", "LABRGB", "RGBOOOOL"]
 
         for channels_str in ambiguous_channels:
             with self.assertRaises(ValueError):
@@ -79,6 +79,7 @@ class TestImageChannelValidation(unittest.TestCase):
 
         for channels_str in unsupported_channels:
             with self.assertRaises(ValueError) as context:
+                print(channels_str)
                 image_channel_instance_factory(channels_str)
 
             # Check if the error message indicates unsupported format
@@ -104,7 +105,7 @@ class TestImageChannelValidation(unittest.TestCase):
 
     # GrayscaleChannels conversion tests
     def test_grayscale_conversion(self):
-        channels_instance = GrayscaleChannels("OOLOOO")
+        channels_instance = GrayscaleChannels("OOGOOO")
         image = np.zeros((100, 100, 6), dtype=np.uint8)
         image[:, :, 2] = 128  # Grayscale value
 


### PR DESCRIPTION
# Introducing a new way of handling image channels
With this change, we can now describe more complex channel representations like (R, G, B, Depth, ...)

The challenge is that there is an infinite number of combinations so we cannot have 1 class/enum for each.
AND we don't want the user to import weird objects and to build on top of it.

This leads to some questions
- How to represent the whole channels of an image? Which structure to use ? Knowing that we want this to be simple and as intuitive as possible..
- For a given representation, how can we convert it to RGB, LAB, GRAY, ... ?

### Solution Proposed

1. String representation

-  1 letter per channel
- Only specific patterns are accepted for color channels:
    - `RGB`
    - `BGR`
    - `G`
    - `LAB`
- `O` should be used as a placeholder for other channels (Depth, ...)

E.g. `RGBO` for (Red, Green, Blue, Depth)

These strings are later used to instantiate a class that handles all conversion logic.

2. `ImageChannels`
 
These objects take the strings from above and then handle all of the logic of converting to an image of given channel representation to rgb/lab. This abstracts away the logic from the feature extractors.

See how it is used with samples
```python
@dataclasses.dataclass
class ImageSample:
    ...
    image_channels: ImageChannels 

    @property
    def image_as_rgb(self) -> np.ndarray:
        return self.image_channels.convert_image_to_rgb(image=self.image)

    @property
    def image_channels_to_visualize(self) -> np.ndarray:
        return self.image_channels.get_channels_to_visualize(image=self.image)

    @property
    def image_as_lab(self) -> np.ndarray:
        return self.image_channels.convert_image_to_lab(image=self.image)
```

### Example of questions
```
--------------------------------------------------------------------------------
Please describe your image channels?
--------------------------------------------------------------------------------
Image Shape: (640, 427, 3)

Enter the channel format representing your image:

  > RGB  : Red, Green, Blue
  > BGR  : Blue, Green, Red
  > G    : Grayscale
  > LAB  : Luminance, A and B color channels

ADDITIONAL CHANNELS?
If your image contains channels other than the standard ones listed above (e.g., Depth, Heat), prefix them with 'O'. 
For instance:
  > ORGBO: Can represent (Heat, Red, Green, Blue, Depth).
  > OBGR:  Can represent (Alpha, Blue, Green, Red).
  > GO:    Can represent (Gray, Depth).

IMPORTANT: Make sure that your answer represents all the image channels.
```


### Something I explored but gave up on
At first, I started with a more custom solution. You can enter any channel type in any order. `OOROBOG` for instance, and then DG would understand which channels are Red, Blue, Green and reorganise. 
The issue is that, it adds lots of complexity in
- The code. 
- The explanations to user.
And at the same time, this really felt like overengineering something that will never be useful.

### Final Notes
I know the design is not perfect, I tried to make it as simple as possible while being general enough.
I also think I should refine the way questions are being asked.
Let me know any thought that comes to your mind