### PR TITLE
Fix classnames

### DIFF
--- a/src/data_gradients/dataset_adapters/config/data_config.py
+++ b/src/data_gradients/dataset_adapters/config/data_config.py
@@ -6,7 +6,7 @@ import platformdirs
 import torch
 from abc import ABC
 from dataclasses import dataclass
-from typing import Dict, Optional, Callable, Union, List
+from typing import Dict, Optional, Callable, Union, List, Mapping
 
 import data_gradients
 from data_gradients.dataset_adapters.config.questions import FixedOptionsQuestion, OpenEndedQuestion, text_to_yellow
@@ -153,7 +153,7 @@ class DataConfig(ABC):
             self.n_classes = json_dict.get("n_classes")
         if self.class_names is None:
             class_names = json_dict.get("class_names")
-            if isinstance(class_names, dict):
+            if isinstance(class_names, Mapping):
                 class_names = {int(k): v for k, v in class_names.items()}
             self.class_names = class_names
         if self.class_names_to_use is None:

--- a/src/data_gradients/dataset_adapters/config/data_config.py
+++ b/src/data_gradients/dataset_adapters/config/data_config.py
@@ -152,7 +152,10 @@ class DataConfig(ABC):
         if self.n_classes is None:
             self.n_classes = json_dict.get("n_classes")
         if self.class_names is None:
-            self.class_names = json_dict.get("class_names")
+            class_names = json_dict.get("class_names")
+            if isinstance(class_names, dict):
+                class_names = {int(k): v for k, v in class_names.items()}
+            self.class_names = class_names
         if self.class_names_to_use is None:
             self.class_names_to_use = json_dict.get("class_names_to_use")
         if self.image_channels is None:
@@ -342,7 +345,7 @@ def resolve_class_names(class_names: Union[List[str], Dict[int, str]], n_classes
             validation=lambda answer: _represents_int(answer) and int(answer) > 0,
         )
         n_classes = int(question.ask())
-        return {f"class_{i}": i for i in range(n_classes)}
+        return {i: f"class_{i}" for i in range(n_classes)}
     elif class_names:
         if isinstance(class_names, list):
             return dict(zip(range(len(class_names)), class_names))


### PR DESCRIPTION
2 cases seem to not be properly handled 

1. Clear mistake in the code where the class_names mapping is reversed in a specific case
2. Loading from cache of class_names when it is a dict loads the ids as str instead of int