### PR TITLE
Fixes a crash when some labels/boxes are NaN

### DIFF
--- a/src/data_gradients/__init__.py
+++ b/src/data_gradients/__init__.py
@@ -1,1 +1,6 @@
 __version__ = "0.3.2"
+
+from .managers.detection_manager import DetectionAnalysisManager
+from .managers.classification_manager import ClassificationAnalysisManager
+
+__all__ = ["DetectionAnalysisManager", "ClassificationAnalysisManager"]

--- a/src/data_gradients/dataset_adapters/exceptions.py
+++ b/src/data_gradients/dataset_adapters/exceptions.py
@@ -1,0 +1,2 @@
+class NonFiniteValuesError(ValueError):
+    pass

--- a/src/data_gradients/dataset_adapters/utils.py
+++ b/src/data_gradients/dataset_adapters/utils.py
@@ -11,6 +11,13 @@ def channels_last_to_first(tensors: torch.Tensor) -> torch.Tensor:
     return tensors.permute(0, 3, 1, 2)
 
 
+def check_all_finite(tensor: torch.Tensor) -> bool:
+    """
+    Check if all elements in the tensor are finite (not NaN or Inf).
+    """
+    return torch.all(torch.isfinite(tensor)).item()
+
+
 def check_all_integers(tensor: torch.Tensor) -> bool:
     return torch.all(torch.eq(tensor, tensor.to(torch.int))).item()
 

--- a/src/data_gradients/managers/abstract_manager.py
+++ b/src/data_gradients/managers/abstract_manager.py
@@ -97,12 +97,6 @@ class AnalysisManagerAbstract(abc.ABC):
             "computer vision datasets. click here: https://hubs.ly/Q01XpHBT0"
         )
 
-        # datasets_tqdm = iter(tqdm(
-        #     zip_longest(self.train_samples_iterator, self.val_samples_iterator, fillvalue=None),
-        #     desc="Analyzing... ",
-        #     total=self.n_batches,
-        # ))
-
         train_samples_iterator = iter(self.train_samples_iterator)
         val_samples_iterator = iter(self.val_samples_iterator)
 
@@ -117,10 +111,6 @@ class AnalysisManagerAbstract(abc.ABC):
         with tqdm(total=self.n_batches, desc="Analyzing... ") as datasets_tqdm:
             i = 0
             while True:
-                if i == self.batches_early_stop:
-                    self._stopped_early = True
-                    break
-
                 try:
                     train_sample = None
                     train_sample = next(train_samples_iterator)
@@ -163,7 +153,15 @@ class AnalysisManagerAbstract(abc.ABC):
 
                 i += 1
                 datasets_tqdm.update()
+
+                # Check for exit conditions
+                # If both train & validation iterators are exhausted, exit the loop
                 if train_sample is None and val_sample is None:
+                    break
+
+                # If the target number of batches has been reached, exit the loop
+                if i == self.batches_early_stop:
+                    self._stopped_early = True
                     break
 
         if non_finite_train_samples > 0 or non_finite_val_samples > 0:

--- a/src/data_gradients/visualize/images.py
+++ b/src/data_gradients/visualize/images.py
@@ -96,6 +96,8 @@ def combine_images_per_split_per_class(images_per_split_per_class: Dict[str, Dic
 
         # This plot is for a single class, which is made of at least 1 split
         class_fig, class_axs = plt.subplots(nrows=1, ncols=len(images_per_split), figsize=(10, 6))
+        # A hack to make sure class_axs is iterable. When is len(images_per_split) == 1, class_axs is not a list
+        class_axs = [class_axs] if len(images_per_split) == 1 else class_axs
         class_fig.subplots_adjust(top=0.9)
         class_fig.suptitle(f"Class: {class_name}", fontsize=36)
 


### PR DESCRIPTION
Test dataset to reproduce. See the attached report generated
[Report.pdf](https://github.com/Deci-AI/data-gradients/files/14420160/Report.pdf)

If batch/sample with NaN is detected it is excluded from processing entirely. But it is tracked and added to list of errors which is not also written to PDF

```
import numpy as np
import torch

from data_gradients import DetectionAnalysisManager

train_samples = [
    # 4 images with labels
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (1, 5), dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (2, 5), dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (3, 5),

 dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (4, 5), dtype=torch.float32)),
]
train_samples[3][1][0:2, 2] = np.nan

valid_samples = [
    # 4 images with labels
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (1, 5), dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (2, 5), dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (3, 5), dtype=torch.float32)),
    (torch.randn((3, 100, 100), dtype=torch.float32), torch.randint(0, 10, (4, 5), dtype=torch.float32)),
]
valid_samples[2][1][0, 2:4] = np.nan
manager = DetectionAnalysisManager(
    train_data=train_samples,
    val_data=valid_samples,
    report_title="Detection Test",
    class_names=["class_1", "class_2", "class_3", "class_4", "class_5", "class_6", "class_7", "class_8", "class_9",
                 "class_10"],
    batches_early_stop=None,
)
manager.run()
```